### PR TITLE
fix: Fix catalogue number uniqueness check for items without deleted …

### DIFF
--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -583,8 +583,10 @@ func (svc *CatalogueService) IsCatalogueNumberUnique(catalogueNumber string, exc
 	query := helpers.DatabaseQuery{}
 	query.Parameters = make(map[string]interface{})
 	query.Query = `
-		MATCH (ci:CatalogueItem {catalogueNumber: $catalogueNumber, deleted: false})
-		WHERE $excludeUid = '' OR ci.uid <> $excludeUid
+		MATCH (ci:CatalogueItem)
+		WHERE ci.catalogueNumber = $catalogueNumber
+		  AND coalesce(ci.deleted, false) = false
+		  AND ($excludeUid = '' OR ci.uid <> $excludeUid)
 		RETURN count(ci) as count
 	`
 	query.Parameters["catalogueNumber"] = catalogueNumber


### PR DESCRIPTION
…property

The previous Cypher query used pattern matching {deleted: false} which would not match nodes that don't have the deleted property set. This caused the endpoint to return isUnique: true even when catalogue items with the same catalogue number existed in the database.

Changed the query to use COALESCE to treat nodes without deleted property as active (non-deleted) items, ensuring accurate uniqueness validation.

- Replace pattern match with explicit WHERE clause
- Use coalesce(ci.deleted, false) to handle nodes without deleted property
- Fixes false positives for catalogue numbers like F18P1L071001

🤖 Generated with [Claude Code](https://claude.com/claude-code)