### PR TITLE
ELIPANDA-479: Add eliResearchers field to Publication API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -2612,6 +2612,13 @@ const docTemplate = `{
                     "description": "eliAuthorsCount is the eli authors count of the publication",
                     "type": "integer"
                 },
+                "eliResearchers": {
+                    "description": "eliResearchers are the connected researchers via HAS_RESEARCHER relationship",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ResearcherRef"
+                    }
+                },
                 "experimentalSystem": {
                     "description": "experimentalSystem is the experimental system of the publication",
                     "type": "string"
@@ -2783,6 +2790,20 @@ const docTemplate = `{
                 },
                 "updatedAt": {
                     "description": "updatedAt is the time when the researcher was last updated",
+                    "type": "string"
+                }
+            }
+        },
+        "models.ResearcherRef": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -2609,6 +2609,13 @@
                     "description": "eliAuthorsCount is the eli authors count of the publication",
                     "type": "integer"
                 },
+                "eliResearchers": {
+                    "description": "eliResearchers are the connected researchers via HAS_RESEARCHER relationship",
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.ResearcherRef"
+                    }
+                },
                 "experimentalSystem": {
                     "description": "experimentalSystem is the experimental system of the publication",
                     "type": "string"
@@ -2780,6 +2787,20 @@
                 },
                 "updatedAt": {
                     "description": "updatedAt is the time when the researcher was last updated",
+                    "type": "string"
+                }
+            }
+        },
+        "models.ResearcherRef": {
+            "type": "object",
+            "properties": {
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -481,6 +481,12 @@ definitions:
       eliAuthorsCount:
         description: eliAuthorsCount is the eli authors count of the publication
         type: integer
+      eliResearchers:
+        description: eliResearchers are the connected researchers via HAS_RESEARCHER
+          relationship
+        items:
+          $ref: '#/definitions/models.ResearcherRef'
+        type: array
       experimentalSystem:
         description: experimentalSystem is the experimental system of the publication
         type: string
@@ -601,6 +607,15 @@ definitions:
         type: string
       updatedAt:
         description: updatedAt is the time when the researcher was last updated
+        type: string
+    type: object
+  models.ResearcherRef:
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
+      uid:
         type: string
     type: object
   models.ResponsiblePersonsInfo:

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -481,6 +481,12 @@ definitions:
       eliAuthorsCount:
         description: eliAuthorsCount is the eli authors count of the publication
         type: integer
+      eliResearchers:
+        description: eliResearchers are the connected researchers via HAS_RESEARCHER
+          relationship
+        items:
+          $ref: '#/definitions/models.ResearcherRef'
+        type: array
       experimentalSystem:
         description: experimentalSystem is the experimental system of the publication
         type: string
@@ -601,6 +607,15 @@ definitions:
         type: string
       updatedAt:
         description: updatedAt is the time when the researcher was last updated
+        type: string
+    type: object
+  models.ResearcherRef:
+    properties:
+      firstName:
+        type: string
+      lastName:
+        type: string
+      uid:
         type: string
     type: object
   models.ResponsiblePersonsInfo:

--- a/services/publications-service/models/publications-models.go
+++ b/services/publications-service/models/publications-models.go
@@ -48,11 +48,18 @@ type Publication struct {
 	UserExperiment          *string                  `json:"userExperiment" neo4j:"prop,userExperiment"`                                         // userExperiment is the user experiment of the publication
 	ExperimentalSystem      *string                  `json:"experimentalSystem" neo4j:"prop,experimentalSystem"`                                 // experimentalSystem is the experimental system of the publication
 	UpdatedAt               *time.Time               `json:"updatedAt" neo4j:"prop,updatedAt"`                                                   // updatedAt is the time when the publication was last updated
+	EliResearchers          []ResearcherRef          `json:"eliResearchers"`                                                                     // eliResearchers are the connected researchers via HAS_RESEARCHER relationship
 }
 
 type AuthorsDepartment struct {
 	Department   codebookModels.Codebook `json:"department" neo4j:"rel,Department,HAS_DEPARTMENT,uid,department"` // department is the department of the publication
 	AuthorsCount int                     `json:"authorsCount" neo4j:"prop,authorsCount"`                          // authorsCount is the authors count of the publication
+}
+
+type ResearcherRef struct {
+	Uid       string `json:"uid"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
 }
 
 type WosAPIResponse struct {


### PR DESCRIPTION
## Summary
- Add `eliResearchers` field to Publication API - array of `{uid, firstName, lastName}`
- Implement `HAS_RESEARCHER` relationship between Publication and Researcher (0:n cardinality)
- Diff-based update logic: only disconnect removed researchers, connect new ones
- Filter out soft-deleted researchers from all queries

## Changes
- **Model**: Added `ResearcherRef` struct and `EliResearchers` field to `Publication`
- **GET**: Returns connected researchers in `eliResearchers` array
- **POST**: Connects specified researchers to new publication
- **PUT**: Compares old vs new researchers, updates only differences

## Test plan
- [x] TestCreatePublicationWithResearchers
- [x] TestGetPublicationWithResearchers  
- [x] TestUpdatePublicationAddResearchers
- [x] TestUpdatePublicationRemoveResearchers
- [x] TestUpdatePublicationReplaceResearchers

🤖 Generated with [Claude Code](https://claude.com/claude-code)