### PR TITLE
Change publications codebooks RoleEdit to ROLE_PUBLICATIONS_EDIT

### DIFF
--- a/services/codebook-service/models/codebook.go
+++ b/services/codebook-service/models/codebook.go
@@ -57,15 +57,15 @@ var CATALOGUE_CATEGORY_AUTOCOMPLETE_CODEBOOK CodebookType = CodebookType{Code: "
 var TEAM_AUTOCOMPLETE_CODEBOOK CodebookType = CodebookType{Code: "TEAM", Type: "AUTOCOMPLETE", NodeLabel: "Team", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, FacilityRelation: "BELONGS_TO_FACILITY"}
 var CONTACT_PERSON_ROLE_CODEBOOK CodebookType = CodebookType{Code: "CONTACT_PERSON_ROLE", Type: "AUTOCOMPLETE", NodeLabel: "ContactPersonRole", RoleEdit: shared.ROLE_ROOM_CARDS_EDIT, FacilityRelation: "BELONGS_TO_FACILITY"}
 var SYSTEM_ATTRIBUTE_CODEBOOK CodebookType = CodebookType{Code: "SYSTEM_ATTRIBUTE", Type: "SIMPLE", NodeLabel: "SystemAttribute", RoleEdit: shared.SYSTEM_ATTRIBUTE_EDIT, FacilityRelation: "BELONGS_TO_FACILITY"}
+var LANGUAGE_CODEBOOK CodebookType = CodebookType{Code: "LANGUAGE", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Language"}
+var COUNTRY_CODEBOOK CodebookType = CodebookType{Code: "COUNTRY", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Country"}
 
 // publications related codebooks
 // UserCall, UserExperiment, PublicationCategory, OpenAccessType, Language, PublicationSupport, State
-var USER_CALL_CODEBOOK CodebookType = CodebookType{Code: "USER_CALL", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "UserCall"}
-var USER_EXPERIMENT_CODEBOOK CodebookType = CodebookType{Code: "USER_EXPERIMENT", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "UserExperiment", FacilityRelation: "BELONGS_TO_FACILITY"}
-var OPEN_ACCESS_TYPE_CODEBOOK CodebookType = CodebookType{Code: "OPEN_ACCESS_TYPE", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "OpenAccessType"}
-var LANGUAGE_CODEBOOK CodebookType = CodebookType{Code: "LANGUAGE", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Language"}
-var COUNTRY_CODEBOOK CodebookType = CodebookType{Code: "COUNTRY", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Country"}
-var DEPARTMENT_CODEBOOK CodebookType = CodebookType{Code: "DEPARTMENT", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Department"}
-var EXPERIMENTAL_SYSTEM_CODEBOOK CodebookType = CodebookType{Code: "EXPERIMENTAL_SYSTEM", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "ExperimentalSystem", FacilityRelation: "BELONGS_TO_FACILITY"}
-var GRANT_CODEBOOK CodebookType = CodebookType{Code: "GRANT", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "Grant", FacilityRelation: "BELONGS_TO_FACILITY"}
-var MEDIA_TYPE_CODEBOOK CodebookType = CodebookType{Code: "MEDIA_TYPE", Type: "SIMPLE", RoleEdit: shared.ROLE_CODEBOOKS_ADMIN, NodeLabel: "MediaType"}
+var USER_CALL_CODEBOOK CodebookType = CodebookType{Code: "USER_CALL", Type: "SIMPLE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "UserCall"}
+var USER_EXPERIMENT_CODEBOOK CodebookType = CodebookType{Code: "USER_EXPERIMENT", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "UserExperiment", FacilityRelation: "BELONGS_TO_FACILITY"}
+var OPEN_ACCESS_TYPE_CODEBOOK CodebookType = CodebookType{Code: "OPEN_ACCESS_TYPE", Type: "SIMPLE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "OpenAccessType"}
+var DEPARTMENT_CODEBOOK CodebookType = CodebookType{Code: "DEPARTMENT", Type: "SIMPLE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "Department"}
+var EXPERIMENTAL_SYSTEM_CODEBOOK CodebookType = CodebookType{Code: "EXPERIMENTAL_SYSTEM", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "ExperimentalSystem", FacilityRelation: "BELONGS_TO_FACILITY"}
+var GRANT_CODEBOOK CodebookType = CodebookType{Code: "GRANT", Type: "AUTOCOMPLETE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "Grant", FacilityRelation: "BELONGS_TO_FACILITY"}
+var MEDIA_TYPE_CODEBOOK CodebookType = CodebookType{Code: "MEDIA_TYPE", Type: "SIMPLE", RoleEdit: shared.ROLE_PUBLICATIONS_EDIT, NodeLabel: "MediaType"}


### PR DESCRIPTION
Move LANGUAGE and COUNTRY codebooks outside publications section (keep ROLE_CODEBOOKS_ADMIN). Update publication-specific codebooks to use ROLE_PUBLICATIONS_EDIT instead of ROLE_CODEBOOKS_ADMIN.