### PR TITLE
feat: deliveryRef query param + cislo/validation fixes

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -3162,6 +3162,13 @@ const docTemplate = `{
                         "name": "provider",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Delivery reference number (cislo jednaci)",
+                        "name": "deliveryRef",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -3159,6 +3159,13 @@
                         "name": "provider",
                         "in": "query",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Delivery reference number (cislo jednaci)",
+                        "name": "deliveryRef",
+                        "in": "query",
+                        "required": true
                     }
                 ],
                 "responses": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -3761,6 +3761,11 @@ paths:
         name: provider
         required: true
         type: string
+      - description: Delivery reference number (cislo jednaci)
+        in: query
+        name: deliveryRef
+        required: true
+        type: string
       produces:
       - application/xml
       responses:

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -3761,6 +3761,11 @@ paths:
         name: provider
         required: true
         type: string
+      - description: Delivery reference number (cislo jednaci)
+        in: query
+        name: deliveryRef
+        required: true
+        type: string
       produces:
       - application/xml
       responses:

--- a/services/publications-service/models/riv-config.go
+++ b/services/publications-service/models/riv-config.go
@@ -21,7 +21,6 @@ const (
 	// Delivery metadata
 	RivDeliveryMode    = "R" // R=new, Z=update, V=deletion
 	RivDeliveryVersion = "01"
-	RivDeliveryRef     = "TODO-REF" // set per delivery
 )
 
 // MediaTypeDruhMap maps MediaType codes to RIV <druh> attribute values

--- a/services/publications-service/publications-handlers.go
+++ b/services/publications-service/publications-handlers.go
@@ -591,6 +591,7 @@ func (h *PublicationsHandlers) GetPublicationsAsCsv() echo.HandlerFunc {
 // @Produce application/xml
 // @Param year query string true "Year of publication"
 // @Param provider query string true "Provider code (grant group code)"
+// @Param deliveryRef query string true "Delivery reference number (cislo jednaci)"
 // @Success 200 "XML file"
 // @Failure 400 "Bad Request"
 // @Failure 500 "Internal Server Error"
@@ -605,8 +606,12 @@ func (h *PublicationsHandlers) ExportRiv() echo.HandlerFunc {
 		if !providerRegex.MatchString(provider) {
 			return helpers.BadRequest("provider must be alphanumeric")
 		}
+		deliveryRef := strings.TrimSpace(c.QueryParam("deliveryRef"))
+		if deliveryRef == "" {
+			return helpers.BadRequest("deliveryRef is required")
+		}
 
-		xmlBytes, filename, err := h.PublicationsService.ExportRiv(year, provider)
+		xmlBytes, filename, err := h.PublicationsService.ExportRiv(year, provider, deliveryRef)
 		if err != nil {
 			log.Error().Err(err).Msg("Error exporting RIV")
 			return echo.ErrInternalServerError

--- a/services/publications-service/publications-riv-export.go
+++ b/services/publications-service/publications-riv-export.go
@@ -93,7 +93,7 @@ type rivResearcherData struct {
 	CitizenshipCode      string
 }
 
-func (svc *PublicationsService) ExportRiv(year string, provider string) ([]byte, string, error) {
+func (svc *PublicationsService) ExportRiv(year string, provider string, deliveryRef string) ([]byte, string, error) {
 	pubs, warnings, err := svc.buildRivData(year, provider)
 	if err != nil {
 		return nil, "", err
@@ -103,7 +103,7 @@ func (svc *PublicationsService) ExportRiv(year string, provider string) ([]byte,
 		log.Warn().Int("warnings", len(warnings)).Msg("RIV export has validation warnings")
 	}
 
-	dodavka := buildRivDodavka(provider, pubs)
+	dodavka := buildRivDodavka(provider, deliveryRef, pubs)
 
 	xmlBytes, err := xml.MarshalIndent(dodavka, "", "  ")
 	if err != nil {
@@ -253,11 +253,6 @@ func (svc *PublicationsService) buildRivData(year string, provider string) ([]ri
 	pubs := make([]rivAggregatedPublication, 0, len(pubOrder))
 	warnings := make([]models.RivValidationWarning, 0)
 
-	// Config validation
-	if strings.Contains(models.RivDeliveryRef, "TODO") {
-		warnings = append(warnings, models.RivValidationWarning{PublicationCode: "", Message: "RivDeliveryRef still contains TODO placeholder"})
-	}
-
 	idCodes := make(map[string]bool)
 	for _, uid := range pubOrder {
 		agg := pubMap[uid]
@@ -314,7 +309,7 @@ func (svc *PublicationsService) buildRivData(year string, provider string) ([]ri
 				warnings = append(warnings, models.RivValidationWarning{PublicationCode: code, Message: "type J: no volume number"})
 			}
 			if agg.row.Issue == nil || *agg.row.Issue == 0 {
-				warnings = append(warnings, models.RivValidationWarning{PublicationCode: code, Message: "type J: issue missing — using yearOfPublication as cislo fallback"})
+				warnings = append(warnings, models.RivValidationWarning{PublicationCode: code, Message: "type J: issue missing — fill in manually before submission"})
 			}
 		case "C":
 			if agg.row.BookTitle == nil || *agg.row.BookTitle == "" {
@@ -388,7 +383,7 @@ func (svc *PublicationsService) buildRivData(year string, provider string) ([]ri
 	return pubs, warnings, nil
 }
 
-func buildRivDodavka(provider string, pubs []rivAggregatedPublication) models.RivDodavka {
+func buildRivDodavka(provider string, deliveryRef string, pubs []rivAggregatedPublication) models.RivDodavka {
 	vysledky := make([]models.RivVysledek, 0, len(pubs))
 	for _, pub := range pubs {
 		v := buildRivVysledek(pub)
@@ -425,7 +420,7 @@ func buildRivDodavka(provider string, pubs []rivAggregatedPublication) models.Ri
 				},
 			},
 			Verze:    models.RivDeliveryVersion,
-			Pruvodka: models.RivPruvodka{CisloJednaci: models.RivDeliveryRef},
+			Pruvodka: models.RivPruvodka{CisloJednaci: deliveryRef},
 		},
 		Obsah: models.RivObsah{Vysledky: vysledky},
 	}
@@ -590,12 +585,10 @@ func buildTypeJ(v *models.RivVysledek, row rivPublicationRow) {
 		v.Rocnik.StatusUdaje = "neuvedeno"
 	}
 
-	// Cislo — fallback to yearOfPublication per RIV spec (cislo does not support neuvedeno)
+	// Cislo — left empty when missing so user can fill manually before submission
 	v.Cislo = &models.RivCislo{}
 	if row.Issue != nil && *row.Issue > 0 {
 		v.Cislo.Value = fmt.Sprintf("%d", *row.Issue)
-	} else {
-		v.Cislo.Value = row.YearOfPublication
 	}
 
 	// Pages

--- a/services/publications-service/publications-service.go
+++ b/services/publications-service/publications-service.go
@@ -40,7 +40,7 @@ type IPublicationsService interface {
 	UpdateGrant(grant *models.Grant, userUID string) (result models.Grant, err error)
 	DeleteGrant(uid string, userUID string) (err error)
 	// RIV export methods
-	ExportRiv(year string, provider string) ([]byte, string, error)
+	ExportRiv(year string, provider string, deliveryRef string) ([]byte, string, error)
 	ValidateRiv(year string, provider string) (models.RivValidationResult, error)
 	// Codebook autocomplete methods
 	GetExperimentalSystemsAutocomplete(searchText string, limit int, facilityCode string) ([]codebookModels.Codebook, error)


### PR DESCRIPTION
## Summary
- `deliveryRef` (číslo jednací) moved from hardcoded constant to required query parameter on export endpoint
- Removed `RivDeliveryRef` constant and TODO warning
- `<cislo>` left empty when issue missing (user fills manually before submission)
- Added type C validation: bookTitle, isbn, publishFormat
- Extended type D validation: publishFormat, conferenceDate, conferencePlace, conferenceScope
- Swagger docs updated

## Test plan
- [ ] `make build` passes
- [ ] Export endpoint returns 400 when `deliveryRef` is missing
- [ ] Export endpoint uses provided `deliveryRef` in `<pruvodka><cislo-jednaci>`
- [ ] Validate endpoint surfaces type C/D data gaps