### PR TITLE
feat(systems): full columnFilter support for leaves endpoint

### DIFF
--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -1214,13 +1214,18 @@ func GetSystemLeavesOrderByClauses(sorting *[]helpers.Sorting) string {
 	}
 
 	allowed := map[string]string{
-		"name":       "toLower(systems.name)",
-		"systemCode": "toLower(systems.systemCode)",
-		"code":       "toLower(systems.systemCode)",
-		"systemType": "toLower(systems.systemType.name)",
-		"zone":       "toLower(systems.zone.code)",
-		"location":   "toLower(systems.location.name)",
-		"eun":        "toLower(systems.physicalItem.eun)",
+		"name":             "toLower(systems.name)",
+		"systemCode":       "toLower(systems.systemCode)",
+		"code":             "toLower(systems.systemCode)",
+		"systemType":       "toLower(systems.systemType.name)",
+		"zone":             "toLower(systems.zone.code)",
+		"location":         "toLower(systems.location.name)",
+		"eun":              "toLower(systems.physicalItem.eun)",
+		"serialNumber":     "toLower(systems.physicalItem.serialNumber)",
+		"catalogueName":    "toLower(systems.physicalItem.catalogueItem.name)",
+		"catalogueNumber":  "toLower(systems.physicalItem.catalogueItem.catalogueNumber)",
+		"importance":       "toLower(systems.importance.name)",
+		"responsible":      "toLower(systems.responsible.name)",
 	}
 
 	clauses := make([]string, 0, len(*sorting))
@@ -1265,29 +1270,255 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	WITH DISTINCT sys
 	`
 
-	// Optional filters (kept intentionally small for this endpoint)
+	// catalogue category filter changes base query
+	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
+	if catalogueCategoryFilter != nil {
+		result.Query += `
+		MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
+		MATCH (cat:CatalogueCategory{uid:$filterCatalogueCategory})
+		OPTIONAL MATCH (cat)-[:HAS_SUBCATEGORY*1..20]->(subs)
+		WITH sys, physicalItem, catalogueItem, ciCategory, collect(subs.uid) + cat.uid as catUids
+		WHERE ciCategory.uid IN catUids
+		WITH sys, physicalItem, catalogueItem, ciCategory
+		`
+		result.Parameters["filterCatalogueCategory"] = (*catalogueCategoryFilter).UID
+	} else if filtering != nil && len(*filtering) > 0 {
+		result.Query += `
+		OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory) WITH sys, physicalItem, catalogueItem, ciCategory
+		`
+	}
+
+	// system name
+	if filterVal := helpers.GetFilterValueString(filtering, "name"); filterVal != nil {
+		result.Query += ` WHERE toLower(sys.name) CONTAINS $filterName `
+		result.Parameters["filterName"] = strings.ToLower(*filterVal)
+	}
+
+	// system description
+	if filterVal := helpers.GetFilterValueString(filtering, "description"); filterVal != nil {
+		result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory WHERE toLower(sys.description) CONTAINS $filterDescription `
+		result.Parameters["filterDescription"] = strings.ToLower(*filterVal)
+	}
+
+	// system level
+	if filterVal := helpers.GetFilterValueListString(filtering, "systemLevel"); filterVal != nil {
+		result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory WHERE sys.systemLevel IN $filterSystemLevel `
+		result.Parameters["filterSystemLevel"] = filterVal
+	}
+
+	// system code
+	if filterVal := helpers.GetFilterValueString(filtering, "systemCode"); filterVal != nil {
+		result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory WHERE toLower(sys.systemCode) CONTAINS $filterSystemCode OR toLower(coalesce(sys.systemCodeOld, '')) CONTAINS $filterSystemCode `
+		result.Parameters["filterSystemCode"] = strings.ToLower(*filterVal)
+	}
+
+	// spare parts coverage
+	if filterVal := helpers.GetFilterValueRangeFloat64(filtering, "sparePartsCoverage"); filterVal != nil {
+		result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory WHERE sys.sp_coverage IS NOT NULL AND (($filterSPCoverageFrom IS NULL OR toFloat(sys.sp_coverage) >= $filterSPCoverageFrom) AND ($filterSPCoverageTo IS NULL OR toFloat(sys.sp_coverage) <= $filterSPCoverageTo)) `
+		result.Parameters["filterSPCoverageFrom"] = filterVal.Min
+		result.Parameters["filterSPCoverageTo"] = filterVal.Max
+	}
+
+	// system type
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "systemType"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st) WHERE st.uid = $filterSystemType `
+		result.Parameters["filterSystemType"] = (*filterVal).UID
+	} else {
+		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st) `
+	}
+
+	// location
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "location"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_LOCATION]->(loc) WHERE loc.uid = $filterLocation `
+		result.Parameters["filterLocation"] = (*filterVal).UID
+	} else {
+		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc) `
+	}
+
+	// zone
 	if filterVal := helpers.GetFilterValueCodebook(filtering, "zone"); filterVal != nil {
-		result.Query += ` MATCH (sys)-[:HAS_ZONE]->(zone:Zone{uid:$filterZoneUID}) `
-		result.Parameters["filterZoneUID"] = (*filterVal).UID
+		result.Query += ` MATCH (sys)-[:HAS_ZONE]->(zone) WHERE zone.uid = $filterZone `
+		result.Parameters["filterZone"] = (*filterVal).UID
 	} else {
 		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone) `
 	}
 
-	if filterVal := helpers.GetFilterValueCodebook(filtering, "systemType"); filterVal != nil {
-		result.Query += ` WITH sys, zone MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st:SystemType{uid:$filterSystemTypeUID}) `
-		result.Parameters["filterSystemTypeUID"] = (*filterVal).UID
+	// responsible
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "responsible"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe) WHERE responsilbe.uid = $filterResponsible `
+		result.Parameters["filterResponsible"] = (*filterVal).UID
 	} else {
-		result.Query += ` WITH sys, zone OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st) `
+		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe) `
+	}
+
+	// importance
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "importance"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_IMPORTANCE]->(imp) WHERE imp.uid = $filterImportance `
+		result.Parameters["filterImportance"] = (*filterVal).UID
+	} else {
+		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp) `
+	}
+
+	// physical item filters
+	itemUsageFilter := helpers.GetFilterValueListString(filtering, "itemUsage")
+	eunFilter := helpers.GetFilterValueString(filtering, "eun")
+	serialNumberFilter := helpers.GetFilterValueString(filtering, "serialNumber")
+	catalogueNumberFilter := helpers.GetFilterValueString(filtering, "catalogueNumber")
+	catalogueNameFilter := helpers.GetFilterValueString(filtering, "catalogueName")
+	supplierFilter := helpers.GetFilterValueCodebook(filtering, "supplier")
+	priceFilter := helpers.GetFilterValueRangeFloat64(filtering, "price")
+	orderFilter := helpers.GetFilterValueString(filtering, "order")
+	orderNameFilter := helpers.GetFilterValueString(filtering, "orderName")
+	orderNumberFilter := helpers.GetFilterValueString(filtering, "orderNumber")
+	orderRequestNumberFilter := helpers.GetFilterValueString(filtering, "orderRequestNumber")
+	orderContractNumberFilter := helpers.GetFilterValueString(filtering, "orderContractNumber")
+
+	if orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil {
+
+		if catalogueCategoryFilter == nil {
+			result.Query += ` MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory) `
+		}
+
+		if orderFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.orderNumber CONTAINS $filterOrder OR order.requestNumber CONTAINS $filterOrder OR order.contractNumber CONTAINS $filterOrder `
+			result.Parameters["filterOrder"] = *orderFilter
+		}
+
+		if orderNameFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.name CONTAINS $filterOrderName `
+			result.Parameters["filterOrderName"] = strings.ToLower(*orderNameFilter)
+		}
+
+		if orderNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.orderNumber CONTAINS $filterOrderNumber `
+			result.Parameters["filterOrderNumber"] = *orderNumberFilter
+		}
+
+		if orderRequestNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.requestNumber CONTAINS $filterOrderRequestNumber `
+			result.Parameters["filterOrderRequestNumber"] = *orderRequestNumberFilter
+		}
+
+		if orderContractNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.contractNumber CONTAINS $filterOrderContractNumber `
+			result.Parameters["filterOrderContractNumber"] = *orderContractNumberFilter
+		}
+
+		if orderFilter == nil && orderNameFilter == nil && orderNumberFilter == nil && orderRequestNumberFilter == nil && orderContractNumberFilter == nil {
+			result.Query += ` OPTIONAL MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) `
+		}
+
+		if itemUsageFilter != nil {
+			result.Query += ` MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage `
+			result.Parameters["filterItemUsage"] = itemUsageFilter
+		} else {
+			result.Query += ` OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) `
+		}
+
+		if supplierFilter != nil {
+			result.Query += ` MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier) WHERE supplier.uid = $filterSupplier `
+			result.Parameters["filterSupplier"] = (*supplierFilter).UID
+		} else {
+			result.Query += ` OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier) `
+		}
+
+		if priceFilter != nil {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, order `
+			result.Query += ` MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Parameters["filterPriceFrom"] = priceFilter.Min
+			result.Parameters["filterPriceTo"] = priceFilter.Max
+		} else {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, order `
+			result.Query += ` OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() `
+		}
+
+		if eunFilter != nil {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WHERE toLower(physicalItem.eun) CONTAINS $filterEUN `
+			result.Parameters["filterEUN"] = strings.ToLower(*eunFilter)
+		}
+
+		if serialNumberFilter != nil {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WHERE toLower(physicalItem.serialNumber) CONTAINS $filterSerialNumber `
+			result.Parameters["filterSerialNumber"] = strings.ToLower(*serialNumberFilter)
+		}
+
+		if catalogueNumberFilter != nil {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WHERE toLower(catalogueItem.catalogueNumber) CONTAINS $filterCatalogueNumber `
+			result.Parameters["filterCatalogueNumber"] = strings.ToLower(*catalogueNumberFilter)
+		}
+
+		if catalogueNameFilter != nil {
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName `
+			result.Parameters["filterCatalogueName"] = strings.ToLower(*catalogueNameFilter)
+		}
+
+		// dynamic property filters
+		for i, filter := range *filtering {
+			if filter.Type == "" {
+				continue
+			}
+
+			if filter.Type == "text" {
+				if filterPropvalue := helpers.GetFilterValueString(filtering, filter.Id); filterPropvalue != nil {
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE toLower(pv.value) contains $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+					result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = strings.ToLower(*filterPropvalue)
+				}
+			} else if filter.Type == "list" {
+				if filterPropvalue := helpers.GetFilterValueListString(filtering, filter.Id); filterPropvalue != nil {
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE pv.value IN $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+					result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = filterPropvalue
+				}
+			} else if filter.Type == "number" {
+				if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE ($propFilterValFrom%v IS NULL OR toFloat(pv.value) >= $propFilterValFrom%v) AND ($propFilterValTo%v IS NULL OR toFloat(pv.value) <= $propFilterValTo%v) `, i, itemTypeByPropType[filter.PropType], i, i, i, i)
+					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+					result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
+					result.Parameters[fmt.Sprintf("propFilterValTo%v", i)] = filterPropvalue.Max
+				}
+			} else if filter.Type == "range" {
+				if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v)
+					WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order, apoc.convert.fromJsonMap(pv.value) as jsonValue
+					WHERE (toFloat(jsonValue.min) <= $propFilterValFrom%[1]v - $propFilterValTo%[1]v)
+					AND (toFloat(jsonValue.max) >= $propFilterValFrom%[1]v + $propFilterValTo%[1]v)
+					`, i, itemTypeByPropType[filter.PropType])
+
+					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+					result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
+					if filterPropvalue.Max == nil {
+						filterPropvalue.Max = &plusMinusZero
+					}
+					result.Parameters[fmt.Sprintf("propFilterValTo%v", i)] = filterPropvalue.Max
+				}
+			}
+		}
+
+	} else {
+		if catalogueCategoryFilter != nil {
+			result.Query += `
+			OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)
+			OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage)
+			OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier) `
+		} else {
+			result.Query += `
+			OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
+			OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)
+			OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage)
+			OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier) `
+		}
 	}
 
 	result.Query += `
-	WITH sys, zone, st
-	OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)
-	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe)
-	OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)
-	OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
-	OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier)
-	OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage)
 	CALL {
 		WITH sys
 		OPTIONAL MATCH fullPath = (root{deleted: false})-[:HAS_SUBSYSTEM*1..50]->(sys)
@@ -1301,7 +1532,6 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	OPTIONAL MATCH (sys)-[:HAS_SUBSYSTEM*1..50]->(subsys{deleted: false})
 	OPTIONAL MATCH (sys)-[:IS_SPARE_FOR]->(spareOUT)
 	OPTIONAL MATCH (sys)<-[:IS_SPARE_FOR]-(spareIN)
-	OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)
 
 	RETURN DISTINCT {
 		uid: sys.uid,
@@ -1375,14 +1605,195 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 	WITH DISTINCT sys
 	`
 
-	if filterVal := helpers.GetFilterValueCodebook(filtering, "zone"); filterVal != nil {
-		result.Query += ` MATCH (sys)-[:HAS_ZONE]->(:Zone{uid:$filterZoneUID}) `
-		result.Parameters["filterZoneUID"] = (*filterVal).UID
+	// catalogue category filter
+	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
+	if catalogueCategoryFilter != nil {
+		result.Query += `
+		MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
+		MATCH (cat:CatalogueCategory{uid:$filterCatalogueCategory})
+		OPTIONAL MATCH (cat)-[:HAS_SUBCATEGORY*1..20]->(subs)
+		WITH sys, physicalItem, catalogueItem, ciCategory, collect(subs.uid) + cat.uid as catUids
+		WHERE ciCategory.uid IN catUids
+		WITH sys, physicalItem, catalogueItem, ciCategory
+		`
+		result.Parameters["filterCatalogueCategory"] = (*catalogueCategoryFilter).UID
 	}
 
+	// system name
+	if filterVal := helpers.GetFilterValueString(filtering, "name"); filterVal != nil {
+		result.Query += ` WITH sys WHERE toLower(sys.name) CONTAINS $filterName `
+		result.Parameters["filterName"] = strings.ToLower(*filterVal)
+	}
+
+	// system description
+	if filterVal := helpers.GetFilterValueString(filtering, "description"); filterVal != nil {
+		result.Query += ` WITH sys WHERE toLower(sys.description) CONTAINS $filterDescription `
+		result.Parameters["filterDescription"] = strings.ToLower(*filterVal)
+	}
+
+	// system level
+	if filterVal := helpers.GetFilterValueListString(filtering, "systemLevel"); filterVal != nil {
+		result.Query += ` WITH sys WHERE sys.systemLevel IN $filterSystemLevel `
+		result.Parameters["filterSystemLevel"] = filterVal
+	}
+
+	// system code
+	if filterVal := helpers.GetFilterValueString(filtering, "systemCode"); filterVal != nil {
+		result.Query += ` WITH sys WHERE toLower(sys.systemCode) CONTAINS $filterSystemCode OR toLower(coalesce(sys.systemCodeOld, '')) CONTAINS $filterSystemCode `
+		result.Parameters["filterSystemCode"] = strings.ToLower(*filterVal)
+	}
+
+	// spare parts coverage
+	if filterVal := helpers.GetFilterValueRangeFloat64(filtering, "sparePartsCoverage"); filterVal != nil {
+		result.Query += ` WITH sys WHERE sys.sp_coverage IS NOT NULL AND (($filterSPCoverageFrom IS NULL OR toFloat(sys.sp_coverage) >= $filterSPCoverageFrom) AND ($filterSPCoverageTo IS NULL OR toFloat(sys.sp_coverage) <= $filterSPCoverageTo)) `
+		result.Parameters["filterSPCoverageFrom"] = filterVal.Min
+		result.Parameters["filterSPCoverageTo"] = filterVal.Max
+	}
+
+	// system type
 	if filterVal := helpers.GetFilterValueCodebook(filtering, "systemType"); filterVal != nil {
-		result.Query += ` MATCH (sys)-[:HAS_SYSTEM_TYPE]->(:SystemType{uid:$filterSystemTypeUID}) `
-		result.Parameters["filterSystemTypeUID"] = (*filterVal).UID
+		result.Query += ` MATCH (sys)-[:HAS_SYSTEM_TYPE]->(:SystemType{uid:$filterSystemType}) `
+		result.Parameters["filterSystemType"] = (*filterVal).UID
+	}
+
+	// location
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "location"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_LOCATION]->(loc) WHERE loc.uid = $filterLocation `
+		result.Parameters["filterLocation"] = (*filterVal).UID
+	}
+
+	// zone
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "zone"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_ZONE]->(:Zone{uid:$filterZone}) `
+		result.Parameters["filterZone"] = (*filterVal).UID
+	}
+
+	// responsible
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "responsible"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_RESPONSIBLE]->(r) WHERE r.uid = $filterResponsible `
+		result.Parameters["filterResponsible"] = (*filterVal).UID
+	}
+
+	// importance
+	if filterVal := helpers.GetFilterValueCodebook(filtering, "importance"); filterVal != nil {
+		result.Query += ` MATCH (sys)-[:HAS_IMPORTANCE]->(i) WHERE i.uid = $filterImportance `
+		result.Parameters["filterImportance"] = (*filterVal).UID
+	}
+
+	// physical item filters
+	itemUsageFilter := helpers.GetFilterValueListString(filtering, "itemUsage")
+	eunFilter := helpers.GetFilterValueString(filtering, "eun")
+	serialNumberFilter := helpers.GetFilterValueString(filtering, "serialNumber")
+	catalogueNumberFilter := helpers.GetFilterValueString(filtering, "catalogueNumber")
+	catalogueNameFilter := helpers.GetFilterValueString(filtering, "catalogueName")
+	supplierFilter := helpers.GetFilterValueCodebook(filtering, "supplier")
+	priceFilter := helpers.GetFilterValueRangeFloat64(filtering, "price")
+	orderFilter := helpers.GetFilterValueString(filtering, "order")
+	orderNameFilter := helpers.GetFilterValueString(filtering, "orderName")
+	orderNumberFilter := helpers.GetFilterValueString(filtering, "orderNumber")
+	orderRequestNumberFilter := helpers.GetFilterValueString(filtering, "orderRequestNumber")
+	orderContractNumberFilter := helpers.GetFilterValueString(filtering, "orderContractNumber")
+
+	hasPhysicalItemFilter := orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil
+
+	if hasPhysicalItemFilter {
+		if catalogueCategoryFilter == nil {
+			result.Query += ` MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory) `
+		}
+
+		if orderFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.orderNumber CONTAINS $filterOrder OR order.requestNumber CONTAINS $filterOrder OR order.contractNumber CONTAINS $filterOrder `
+			result.Parameters["filterOrder"] = *orderFilter
+		}
+		if orderNameFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.name CONTAINS $filterOrderName `
+			result.Parameters["filterOrderName"] = strings.ToLower(*orderNameFilter)
+		}
+		if orderNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.orderNumber CONTAINS $filterOrderNumber `
+			result.Parameters["filterOrderNumber"] = *orderNumberFilter
+		}
+		if orderRequestNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.requestNumber CONTAINS $filterOrderRequestNumber `
+			result.Parameters["filterOrderRequestNumber"] = *orderRequestNumberFilter
+		}
+		if orderContractNumberFilter != nil {
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.contractNumber CONTAINS $filterOrderContractNumber `
+			result.Parameters["filterOrderContractNumber"] = *orderContractNumberFilter
+		}
+
+		if itemUsageFilter != nil {
+			result.Query += ` MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage `
+			result.Parameters["filterItemUsage"] = itemUsageFilter
+		}
+		if supplierFilter != nil {
+			result.Query += ` MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier) WHERE supplier.uid = $filterSupplier `
+			result.Parameters["filterSupplier"] = (*supplierFilter).UID
+		}
+		if priceFilter != nil {
+			result.Query += ` WITH sys, physicalItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Parameters["filterPriceFrom"] = priceFilter.Min
+			result.Parameters["filterPriceTo"] = priceFilter.Max
+		}
+		if eunFilter != nil {
+			result.Query += ` WITH sys, physicalItem WHERE toLower(physicalItem.eun) CONTAINS $filterEUN `
+			result.Parameters["filterEUN"] = strings.ToLower(*eunFilter)
+		}
+		if serialNumberFilter != nil {
+			result.Query += ` WITH sys, physicalItem WHERE toLower(physicalItem.serialNumber) CONTAINS $filterSerialNumber `
+			result.Parameters["filterSerialNumber"] = strings.ToLower(*serialNumberFilter)
+		}
+		if catalogueNumberFilter != nil {
+			result.Query += ` WITH sys, catalogueItem WHERE toLower(catalogueItem.catalogueNumber) CONTAINS $filterCatalogueNumber `
+			result.Parameters["filterCatalogueNumber"] = strings.ToLower(*catalogueNumberFilter)
+		}
+		if catalogueNameFilter != nil {
+			result.Query += ` WITH sys, catalogueItem WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName `
+			result.Parameters["filterCatalogueName"] = strings.ToLower(*catalogueNameFilter)
+		}
+
+		// dynamic property filters
+		if filtering != nil {
+			for i, filter := range *filtering {
+				if filter.Type == "" {
+					continue
+				}
+				if filter.Type == "text" {
+					if filterPropvalue := helpers.GetFilterValueString(filtering, filter.Id); filterPropvalue != nil {
+						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE toLower(pv.value) contains $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+						result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = strings.ToLower(*filterPropvalue)
+					}
+				} else if filter.Type == "list" {
+					if filterPropvalue := helpers.GetFilterValueListString(filtering, filter.Id); filterPropvalue != nil {
+						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE pv.value IN $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+						result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = filterPropvalue
+					}
+				} else if filter.Type == "number" {
+					if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
+						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE ($propFilterValFrom%v IS NULL OR toFloat(pv.value) >= $propFilterValFrom%v) AND ($propFilterValTo%v IS NULL OR toFloat(pv.value) <= $propFilterValTo%v) `, i, itemTypeByPropType[filter.PropType], i, i, i, i)
+						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+						result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
+						result.Parameters[fmt.Sprintf("propFilterValTo%v", i)] = filterPropvalue.Max
+					}
+				} else if filter.Type == "range" {
+					if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
+						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v)
+						WITH sys, apoc.convert.fromJsonMap(pv.value) as jsonValue
+						WHERE (toFloat(jsonValue.min) <= $propFilterValFrom%[1]v - $propFilterValTo%[1]v)
+						AND (toFloat(jsonValue.max) >= $propFilterValFrom%[1]v + $propFilterValTo%[1]v)
+						`, i, itemTypeByPropType[filter.PropType])
+						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
+						result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
+						if filterPropvalue.Max == nil {
+							filterPropvalue.Max = &plusMinusZero
+						}
+						result.Parameters[fmt.Sprintf("propFilterValTo%v", i)] = filterPropvalue.Max
+					}
+				}
+			}
+		}
 	}
 
 	result.Query += ` RETURN COUNT(DISTINCT sys) as count `

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -536,12 +536,12 @@ func GetSystemsSearchFilterQueryOnly(searchString string, facilityCode string, f
 
 		if priceFilter != nil {
 			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, order `
-			result.Query += ` MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Query += ` MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order) WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
 			result.Parameters["filterPriceFrom"] = priceFilter.Min
 			result.Parameters["filterPriceTo"] = priceFilter.Max
 		} else {
 			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, order `
-			result.Query += ` OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() `
+			result.Query += ` OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order) `
 		}
 
 		if eunFilter != nil {
@@ -1068,7 +1068,7 @@ func GetSubSystemsQuery(parentUID string, facilityCode string) (result helpers.D
 	OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)  
 	OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)  
 	OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st)	
-	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe)
+	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)
 	OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)
 	OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)	
 	OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier)
@@ -1108,7 +1108,7 @@ func GetSubSystemsQuery(parentUID string, facilityCode string) (result helpers.D
 	location: case when loc is not null then {uid: loc.uid, name: loc.name, code: loc.code} else null end,
 	zone: case when zone is not null then {uid: zone.uid, name: zone.name, code: zone.code} else null end,
 	systemType: case when st is not null then {uid: st.uid, name: st.name} else null end,
-	responsible: case when responsilbe is not null then {uid: responsilbe.uid, name: responsilbe.lastName + " " + responsilbe.firstName} else null end,
+	responsible: case when responsible is not null then {uid: responsible.uid, name: responsible.lastName + " " + responsible.firstName} else null end,
 	importance: case when imp is not null then {uid: imp.uid, name: imp.name} else null end,	
 	lastUpdateTime: sys.lastUpdateTime,
 	lastUpdateBy: sys.lastUpdateBy,	
@@ -1345,10 +1345,10 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 
 	// responsible
 	if filterVal := helpers.GetFilterValueCodebook(filtering, "responsible"); filterVal != nil {
-		result.Query += ` MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe) WHERE responsilbe.uid = $filterResponsible `
+		result.Query += ` MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible) WHERE responsible.uid = $filterResponsible `
 		result.Parameters["filterResponsible"] = (*filterVal).UID
 	} else {
-		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe) `
+		result.Query += ` OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible) `
 	}
 
 	// importance
@@ -1433,35 +1433,35 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 		}
 
 		if priceFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, order `
-			result.Query += ` MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, order `
+			result.Query += ` MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order) WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
 			result.Parameters["filterPriceFrom"] = priceFilter.Min
 			result.Parameters["filterPriceTo"] = priceFilter.Max
 		} else {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, order `
-			result.Query += ` OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, order `
+			result.Query += ` OPTIONAL MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order) `
 		}
 
 		if eunFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 			result.Query += ` WHERE toLower(physicalItem.eun) CONTAINS $filterEUN `
 			result.Parameters["filterEUN"] = strings.ToLower(*eunFilter)
 		}
 
 		if serialNumberFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 			result.Query += ` WHERE toLower(physicalItem.serialNumber) CONTAINS $filterSerialNumber `
 			result.Parameters["filterSerialNumber"] = strings.ToLower(*serialNumberFilter)
 		}
 
 		if catalogueNumberFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 			result.Query += ` WHERE toLower(catalogueItem.catalogueNumber) CONTAINS $filterCatalogueNumber `
 			result.Parameters["filterCatalogueNumber"] = strings.ToLower(*catalogueNumberFilter)
 		}
 
 		if catalogueNameFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+			result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 			result.Query += ` WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName `
 			result.Parameters["filterCatalogueName"] = strings.ToLower(*catalogueNameFilter)
 		}
@@ -1474,21 +1474,21 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 
 			if filter.Type == "text" {
 				if filterPropvalue := helpers.GetFilterValueString(filtering, filter.Id); filterPropvalue != nil {
-					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE toLower(pv.value) contains $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
 					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 					result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = strings.ToLower(*filterPropvalue)
 				}
 			} else if filter.Type == "list" {
 				if filterPropvalue := helpers.GetFilterValueListString(filtering, filter.Id); filterPropvalue != nil {
-					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE pv.value IN $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
 					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 					result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = filterPropvalue
 				}
 			} else if filter.Type == "number" {
 				if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
-					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE ($propFilterValFrom%v IS NULL OR toFloat(pv.value) >= $propFilterValFrom%v) AND ($propFilterValTo%v IS NULL OR toFloat(pv.value) <= $propFilterValTo%v) `, i, itemTypeByPropType[filter.PropType], i, i, i, i)
 					result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 					result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
@@ -1496,9 +1496,9 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 				}
 			} else if filter.Type == "range" {
 				if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
-					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order `
+					result.Query += ` WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order `
 					result.Query += fmt.Sprintf(` MATCH(prop{uid: $propUID%v})<-[pv]-(%v)
-					WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsilbe, loc, zone, st, supplier, ol, order, apoc.convert.fromJsonMap(pv.value) as jsonValue
+					WITH sys, physicalItem, catalogueItem, ciCategory, itemUsage, imp, responsible, loc, zone, st, supplier, ol, order, apoc.convert.fromJsonMap(pv.value) as jsonValue
 					WHERE (toFloat(jsonValue.min) <= $propFilterValFrom%[1]v - $propFilterValTo%[1]v)
 					AND (toFloat(jsonValue.max) >= $propFilterValFrom%[1]v + $propFilterValTo%[1]v)
 					`, i, itemTypeByPropType[filter.PropType])
@@ -1563,7 +1563,7 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 		location: case when loc is not null then {uid: loc.uid, name: loc.name, code: loc.code} else null end,
 		zone: case when zone is not null then {uid: zone.uid, name: zone.name, code: zone.code} else null end,
 		systemType: case when st is not null then {uid: st.uid, name: st.name} else null end,
-		responsible: case when responsilbe is not null then {uid: responsilbe.uid, name: responsilbe.lastName + " " + responsilbe.firstName} else null end,
+		responsible: case when responsible is not null then {uid: responsible.uid, name: responsible.lastName + " " + responsible.firstName} else null end,
 		importance: case when imp is not null then {uid: imp.uid, name: imp.name} else null end,
 		lastUpdateTime: sys.lastUpdateTime,
 		lastUpdateBy: sys.lastUpdateBy,
@@ -1749,7 +1749,7 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 			result.Parameters["filterSupplier"] = (*supplierFilter).UID
 		}
 		if priceFilter != nil {
-			result.Query += ` WITH sys, physicalItem, catalogueItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Query += ` WITH sys, physicalItem, catalogueItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order) WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
 			result.Parameters["filterPriceFrom"] = priceFilter.Min
 			result.Parameters["filterPriceTo"] = priceFilter.Max
 		}
@@ -1830,7 +1830,7 @@ func GetSystemsByUidsQuery(uids []string) (result helpers.DatabaseQuery) {
 	OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)  
 	OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)  
 	OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st)	
-	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe)
+	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)
 	OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)
 	OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)	
 	OPTIONAL MATCH (catalogueItem)-[:HAS_SUPPLIER]->(supplier)
@@ -1866,7 +1866,7 @@ func GetSystemsByUidsQuery(uids []string) (result helpers.DatabaseQuery) {
 	location: case when loc is not null then {uid: loc.uid, name: loc.name, code: loc.code} else null end,
 	zone: case when zone is not null then {uid: zone.uid, name: zone.name, code: zone.code} else null end,
 	systemType: case when st is not null then {uid: st.uid, name: st.name} else null end,
-	responsible: case when responsilbe is not null then {uid: responsilbe.uid, name: responsilbe.lastName + " " + responsilbe.firstName} else null end,
+	responsible: case when responsible is not null then {uid: responsible.uid, name: responsible.lastName + " " + responsible.firstName} else null end,
 	importance: case when imp is not null then {uid: imp.uid, name: imp.name} else null end,	
 	lastUpdateTime: sys.lastUpdateTime,
 	lastUpdateBy: sys.lastUpdateBy,	
@@ -1909,7 +1909,7 @@ func SystemDetailQuery(uid string, facilityCode string) (result helpers.Database
 	OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)  
 	OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)  
 	OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st)	
-	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe)
+	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)
 	OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)
 	OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)	
 	OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage)
@@ -1940,7 +1940,7 @@ func SystemDetailQuery(uid string, facilityCode string) (result helpers.Database
 	location: case when loc is not null then {uid: loc.uid, name: loc.name, code: loc.code} else null end,
 	zone: case when zone is not null then {uid: zone.uid, name: zone.name} else null end,
 	systemType: case when st is not null then {uid: st.uid, name: st.name} else null end,
-	responsible: case when responsilbe is not null then {uid: responsilbe.uid, name: responsilbe.lastName + " " + responsilbe.firstName} else null end,
+	responsible: case when responsible is not null then {uid: responsible.uid, name: responsible.lastName + " " + responsible.firstName} else null end,
 	importance: case when imp is not null then {uid: imp.uid, name: imp.name} else null end,	
 	lastUpdateTime: sys.lastUpdateTime,
 	lastUpdateBy: sys.lastUpdateBy,	
@@ -1978,7 +1978,7 @@ func GetSystemByEunQuery(eun string) (result helpers.DatabaseQuery) {
 	OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)  
 	OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)  
 	OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st)	
-	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsilbe)
+	OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)
 	OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)		
 	OPTIONAL MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage)
 	CALL {
@@ -2004,7 +2004,7 @@ func GetSystemByEunQuery(eun string) (result helpers.DatabaseQuery) {
 	location: case when loc is not null then {uid: loc.uid, name: loc.name, code: loc.code} else null end,
 	zone: case when zone is not null then {uid: zone.uid, name: zone.name} else null end,
 	systemType: case when st is not null then {uid: st.uid, name: st.name} else null end,
-	responsible: case when responsilbe is not null then {uid: responsilbe.uid, name: responsilbe.lastName + " " + responsilbe.firstName} else null end,
+	responsible: case when responsible is not null then {uid: responsible.uid, name: responsible.lastName + " " + responsible.firstName} else null end,
 	importance: case when imp is not null then {uid: imp.uid, name: imp.name} else null end,	
 	subsystems: case when subsys is not null then collect({uid: subsys.uid, name: subsys.name}) else null end,
 	physicalItem: case when physicalItem is not null then {

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -1373,7 +1373,17 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	orderRequestNumberFilter := helpers.GetFilterValueString(filtering, "orderRequestNumber")
 	orderContractNumberFilter := helpers.GetFilterValueString(filtering, "orderContractNumber")
 
-	if orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil {
+	hasDynamicPropFilter := false
+	if filtering != nil {
+		for _, f := range *filtering {
+			if f.Type != "" {
+				hasDynamicPropFilter = true
+				break
+			}
+		}
+	}
+
+	if orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil || priceFilter != nil || hasDynamicPropFilter {
 
 		if catalogueCategoryFilter == nil {
 			result.Query += ` MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory) `
@@ -1385,7 +1395,7 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 		}
 
 		if orderNameFilter != nil {
-			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.name CONTAINS $filterOrderName `
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE toLower(order.name) CONTAINS $filterOrderName `
 			result.Parameters["filterOrderName"] = strings.ToLower(*orderNameFilter)
 		}
 
@@ -1605,20 +1615,7 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 	WITH DISTINCT sys
 	`
 
-	// catalogue category filter
-	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
-	if catalogueCategoryFilter != nil {
-		result.Query += `
-		MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
-		MATCH (cat:CatalogueCategory{uid:$filterCatalogueCategory})
-		OPTIONAL MATCH (cat)-[:HAS_SUBCATEGORY*1..20]->(subs)
-		WITH sys, physicalItem, catalogueItem, ciCategory, collect(subs.uid) + cat.uid as catUids
-		WHERE ciCategory.uid IN catUids
-		WITH sys, physicalItem, catalogueItem, ciCategory
-		`
-		result.Parameters["filterCatalogueCategory"] = (*catalogueCategoryFilter).UID
-	}
-
+	// system-level filters (only need sys, run before physical item matches)
 	// system name
 	if filterVal := helpers.GetFilterValueString(filtering, "name"); filterVal != nil {
 		result.Query += ` WITH sys WHERE toLower(sys.name) CONTAINS $filterName `
@@ -1680,7 +1677,8 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 		result.Parameters["filterImportance"] = (*filterVal).UID
 	}
 
-	// physical item filters
+	// physical item / catalogue filters
+	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
 	itemUsageFilter := helpers.GetFilterValueListString(filtering, "itemUsage")
 	eunFilter := helpers.GetFilterValueString(filtering, "eun")
 	serialNumberFilter := helpers.GetFilterValueString(filtering, "serialNumber")
@@ -1694,10 +1692,30 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 	orderRequestNumberFilter := helpers.GetFilterValueString(filtering, "orderRequestNumber")
 	orderContractNumberFilter := helpers.GetFilterValueString(filtering, "orderContractNumber")
 
-	hasPhysicalItemFilter := orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil
+	hasDynamicPropFilter := false
+	if filtering != nil {
+		for _, f := range *filtering {
+			if f.Type != "" {
+				hasDynamicPropFilter = true
+				break
+			}
+		}
+	}
+
+	hasPhysicalItemFilter := orderContractNumberFilter != nil || orderRequestNumberFilter != nil || orderNumberFilter != nil || orderNameFilter != nil || itemUsageFilter != nil || eunFilter != nil || serialNumberFilter != nil || catalogueNumberFilter != nil || catalogueNameFilter != nil || supplierFilter != nil || catalogueCategoryFilter != nil || orderFilter != nil || priceFilter != nil || hasDynamicPropFilter
 
 	if hasPhysicalItemFilter {
-		if catalogueCategoryFilter == nil {
+		if catalogueCategoryFilter != nil {
+			result.Query += `
+			MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory)
+			MATCH (cat:CatalogueCategory{uid:$filterCatalogueCategory})
+			OPTIONAL MATCH (cat)-[:HAS_SUBCATEGORY*1..20]->(subs)
+			WITH sys, physicalItem, catalogueItem, ciCategory, collect(subs.uid) + cat.uid as catUids
+			WHERE ciCategory.uid IN catUids
+			WITH sys, physicalItem, catalogueItem
+			`
+			result.Parameters["filterCatalogueCategory"] = (*catalogueCategoryFilter).UID
+		} else {
 			result.Query += ` MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)-[:IS_BASED_ON]->(catalogueItem)-[:BELONGS_TO_CATEGORY]->(ciCategory) `
 		}
 
@@ -1706,7 +1724,7 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 			result.Parameters["filterOrder"] = *orderFilter
 		}
 		if orderNameFilter != nil {
-			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE order.name CONTAINS $filterOrderName `
+			result.Query += ` MATCH (physicalItem)<-[:HAS_ORDER_LINE]-(order) WHERE toLower(order.name) CONTAINS $filterOrderName `
 			result.Parameters["filterOrderName"] = strings.ToLower(*orderNameFilter)
 		}
 		if orderNumberFilter != nil {
@@ -1731,24 +1749,24 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 			result.Parameters["filterSupplier"] = (*supplierFilter).UID
 		}
 		if priceFilter != nil {
-			result.Query += ` WITH sys, physicalItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
+			result.Query += ` WITH sys, physicalItem, catalogueItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-() WHERE ($filterPriceFrom IS NULL OR ol.price >= $filterPriceFrom) AND ($filterPriceTo IS NULL OR ol.price <= $filterPriceTo) `
 			result.Parameters["filterPriceFrom"] = priceFilter.Min
 			result.Parameters["filterPriceTo"] = priceFilter.Max
 		}
 		if eunFilter != nil {
-			result.Query += ` WITH sys, physicalItem WHERE toLower(physicalItem.eun) CONTAINS $filterEUN `
+			result.Query += ` WITH sys, physicalItem, catalogueItem WHERE toLower(physicalItem.eun) CONTAINS $filterEUN `
 			result.Parameters["filterEUN"] = strings.ToLower(*eunFilter)
 		}
 		if serialNumberFilter != nil {
-			result.Query += ` WITH sys, physicalItem WHERE toLower(physicalItem.serialNumber) CONTAINS $filterSerialNumber `
+			result.Query += ` WITH sys, physicalItem, catalogueItem WHERE toLower(physicalItem.serialNumber) CONTAINS $filterSerialNumber `
 			result.Parameters["filterSerialNumber"] = strings.ToLower(*serialNumberFilter)
 		}
 		if catalogueNumberFilter != nil {
-			result.Query += ` WITH sys, catalogueItem WHERE toLower(catalogueItem.catalogueNumber) CONTAINS $filterCatalogueNumber `
+			result.Query += ` WITH sys, physicalItem, catalogueItem WHERE toLower(catalogueItem.catalogueNumber) CONTAINS $filterCatalogueNumber `
 			result.Parameters["filterCatalogueNumber"] = strings.ToLower(*catalogueNumberFilter)
 		}
 		if catalogueNameFilter != nil {
-			result.Query += ` WITH sys, catalogueItem WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName `
+			result.Query += ` WITH sys, physicalItem, catalogueItem WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName `
 			result.Parameters["filterCatalogueName"] = strings.ToLower(*catalogueNameFilter)
 		}
 
@@ -1760,27 +1778,27 @@ func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string,
 				}
 				if filter.Type == "text" {
 					if filterPropvalue := helpers.GetFilterValueString(filtering, filter.Id); filterPropvalue != nil {
-						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE toLower(pv.value) contains $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+						result.Query += fmt.Sprintf(` WITH sys, physicalItem, catalogueItem MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE toLower(pv.value) contains $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
 						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 						result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = strings.ToLower(*filterPropvalue)
 					}
 				} else if filter.Type == "list" {
 					if filterPropvalue := helpers.GetFilterValueListString(filtering, filter.Id); filterPropvalue != nil {
-						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE pv.value IN $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
+						result.Query += fmt.Sprintf(` WITH sys, physicalItem, catalogueItem MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE pv.value IN $propFilterVal%v `, i, itemTypeByPropType[filter.PropType], i)
 						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 						result.Parameters[fmt.Sprintf("propFilterVal%v", i)] = filterPropvalue
 					}
 				} else if filter.Type == "number" {
 					if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
-						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE ($propFilterValFrom%v IS NULL OR toFloat(pv.value) >= $propFilterValFrom%v) AND ($propFilterValTo%v IS NULL OR toFloat(pv.value) <= $propFilterValTo%v) `, i, itemTypeByPropType[filter.PropType], i, i, i, i)
+						result.Query += fmt.Sprintf(` WITH sys, physicalItem, catalogueItem MATCH(prop{uid: $propUID%v})<-[pv]-(%v) WHERE ($propFilterValFrom%v IS NULL OR toFloat(pv.value) >= $propFilterValFrom%v) AND ($propFilterValTo%v IS NULL OR toFloat(pv.value) <= $propFilterValTo%v) `, i, itemTypeByPropType[filter.PropType], i, i, i, i)
 						result.Parameters[fmt.Sprintf("propUID%v", i)] = filter.Id
 						result.Parameters[fmt.Sprintf("propFilterValFrom%v", i)] = filterPropvalue.Min
 						result.Parameters[fmt.Sprintf("propFilterValTo%v", i)] = filterPropvalue.Max
 					}
 				} else if filter.Type == "range" {
 					if filterPropvalue := helpers.GetFilterValueRangeFloat64(filtering, filter.Id); filterPropvalue != nil {
-						result.Query += fmt.Sprintf(` WITH sys MATCH(prop{uid: $propUID%v})<-[pv]-(%v)
-						WITH sys, apoc.convert.fromJsonMap(pv.value) as jsonValue
+						result.Query += fmt.Sprintf(` WITH sys, physicalItem, catalogueItem MATCH(prop{uid: $propUID%v})<-[pv]-(%v)
+						WITH sys, physicalItem, catalogueItem, apoc.convert.fromJsonMap(pv.value) as jsonValue
 						WHERE (toFloat(jsonValue.min) <= $propFilterValFrom%[1]v - $propFilterValTo%[1]v)
 						AND (toFloat(jsonValue.max) >= $propFilterValFrom%[1]v + $propFilterValTo%[1]v)
 						`, i, itemTypeByPropType[filter.PropType])

--- a/services/systems-service/systems-db-queries_leaves_test.go
+++ b/services/systems-service/systems-db-queries_leaves_test.go
@@ -1,0 +1,152 @@
+package systemsService
+
+import (
+	"testing"
+
+	"panda/apigateway/helpers"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSystemLeavesByParentUIDQuery_NoFilters(t *testing.T) {
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil)
+
+	assert.Equal(t, "systems", query.ReturnAlias)
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_SYSTEM_TYPE]->(st)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_LOCATION]->(loc)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_IMPORTANCE]->(imp)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "SKIP $skip LIMIT $limit")
+	assert.Equal(t, "parent-uid", query.Parameters["parentUID"])
+	assert.Equal(t, "FAC", query.Parameters["facilityCode"])
+}
+
+func TestGetSystemLeavesByParentUIDQuery_SystemNameFilter(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "name", Value: "Pump"}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "toLower(sys.name) CONTAINS $filterName")
+	assert.Equal(t, "pump", query.Parameters["filterName"])
+}
+
+func TestGetSystemLeavesByParentUIDQuery_ZoneFilter(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "zone", Value: map[string]interface{}{"uid": "zone-1", "name": "Zone A"}}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:HAS_ZONE]->(zone) WHERE zone.uid = $filterZone")
+	assert.NotContains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)")
+	assert.Equal(t, "zone-1", query.Parameters["filterZone"])
+}
+
+func TestGetSystemLeavesByParentUIDQuery_ItemUsageFilter(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "itemUsage", Value: []interface{}{"usage-1", "usage-2"}}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage")
+	assert.Equal(t, &[]string{"usage-1", "usage-2"}, query.Parameters["filterItemUsage"])
+}
+
+func TestGetSystemLeavesByParentUIDQuery_PriceFilterAlone(t *testing.T) {
+	min := 100.0
+	max := 500.0
+	filters := []helpers.ColumnFilter{{Id: "price", Value: map[string]interface{}{"min": min, "max": max}}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)")
+	assert.Contains(t, query.Query, "ol.price >= $filterPriceFrom")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_OrderNameCaseInsensitive(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "orderName", Value: "Main Order"}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "toLower(order.name) CONTAINS $filterOrderName")
+	assert.Equal(t, "main order", query.Parameters["filterOrderName"])
+}
+
+func TestGetSystemLeavesByParentUIDQuery_DynamicPropFilterAlone(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "prop-uid-1", Value: "test-value", Type: "text", PropType: "PHYSICAL_ITEM"}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "MATCH(prop{uid: $propUID0})<-[pv]-(physicalItem)")
+	assert.Contains(t, query.Query, "toLower(pv.value) contains $propFilterVal0")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_ResponsibleVariableName(t *testing.T) {
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil)
+
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)")
+	assert.NotContains(t, query.Query, "responsilbe")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_Sorting(t *testing.T) {
+	sorting := []helpers.Sorting{{ID: "importance", DESC: true}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, &sorting, nil)
+
+	assert.Contains(t, query.Query, "ORDER BY toLower(systems.importance.name) DESC")
+}
+
+// Count query tests
+
+func TestGetSystemLeavesByParentUIDCountQuery_NoFilters(t *testing.T) {
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", nil)
+
+	assert.Equal(t, "count", query.ReturnAlias)
+	assert.Contains(t, query.Query, "RETURN COUNT(DISTINCT sys) as count")
+	assert.NotContains(t, query.Query, "SKIP")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_ItemUsageFilter(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "itemUsage", Value: []interface{}{"usage-1"}}}
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_PriceFilterAlone(t *testing.T) {
+	min := 100.0
+	filters := []helpers.ColumnFilter{{Id: "price", Value: map[string]interface{}{"min": min}}}
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+
+	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
+	assert.Contains(t, query.Query, "ol.price >= $filterPriceFrom")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_DynamicPropVariableScoping(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "prop-uid-1", Value: "test", Type: "text", PropType: "PHYSICAL_ITEM"}}
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+
+	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem MATCH(prop{uid:")
+	assert.NotContains(t, query.Query, "WITH sys MATCH(prop{uid:")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_CombinedPriceAndCatalogueName(t *testing.T) {
+	min := 50.0
+	filters := []helpers.ColumnFilter{
+		{Id: "price", Value: map[string]interface{}{"min": min}},
+		{Id: "catalogueName", Value: "sensor"},
+	}
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+
+	// Both physicalItem and catalogueItem must stay in scope
+	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)")
+	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_SystemLevelFilterBeforeCategory(t *testing.T) {
+	filters := []helpers.ColumnFilter{
+		{Id: "systemLevel", Value: []interface{}{"KEY_SYSTEMS"}},
+		{Id: "category", Value: map[string]interface{}{"uid": "cat-1", "name": "Cat"}},
+	}
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+
+	// System-level filter should not drop category vars
+	assert.Contains(t, query.Query, "sys.systemLevel IN $filterSystemLevel")
+	assert.Contains(t, query.Query, "CatalogueCategory{uid:$filterCatalogueCategory}")
+}


### PR DESCRIPTION
## Summary
- Leaves endpoint (`/v1/system/:uid/leaves`) previously only supported `zone` and `systemType` column filters — all others were silently ignored
- Added full filter parity with the main systems search endpoint: system-level filters (name, description, systemLevel, systemCode, sparePartsCoverage), codebook relationships (location, responsible, importance), physical item filters (itemUsage, eun, serialNumber, catalogueNumber, catalogueName, supplier, price), order filters, catalogue category with recursive subcategories, and dynamic property filters
- Updated count query to mirror all filters for accurate pagination
- Added sorting support for serialNumber, catalogueName, catalogueNumber, importance, responsible

## Test plan
- [x] Build passes (`make build`)
- [x] Existing tests pass (`go test ./services/systems-service/...`)
- [x] Manual test: filter leaves by `itemUsage` — previously returned unfiltered results, now correctly filters
- [x] Verify pagination count matches filtered results