### PR TITLE
feat(catalogue): PATCH endpoint for partial item updates with audit trail

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -776,10 +776,13 @@ const docTemplate = `{
                         }
                     },
                     "400": {
-                        "description": "Bad Request"
+                        "description": "Bad Request — malformed body, missing lastUpdateTime, or unknown supplier/category/property UID"
+                    },
+                    "404": {
+                        "description": "Not Found — catalogue item does not exist"
                     },
                     "409": {
-                        "description": "Conflict"
+                        "description": "Conflict — lastUpdateTime mismatch or concurrent update detected"
                     },
                     "500": {
                         "description": "Internal server error"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -732,6 +732,59 @@ const docTemplate = `{
                         "description": "Internal server error"
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Applies a partial update to a catalogue item. Only fields present in the JSON body are modified.\nRequired: lastUpdateTime (for conflict detection). Supported keys: name, catalogueNumber, description, manufacturerUrl, manufacturerNumber, supplier, category, details.\nScalar fields set to JSON null are cleared. Missing keys are left untouched. Details are merged (no deletion); send value:null to clear a single detail's value.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalogue"
+                ],
+                "summary": "Partially update catalogue item",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Catalogue item UID",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Partial catalogue item payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CatalogueItem"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "409": {
+                        "description": "Conflict"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
             }
         },
         "/v1/catalogue/item/{uid}/image": {

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -773,10 +773,13 @@
                         }
                     },
                     "400": {
-                        "description": "Bad Request"
+                        "description": "Bad Request — malformed body, missing lastUpdateTime, or unknown supplier/category/property UID"
+                    },
+                    "404": {
+                        "description": "Not Found — catalogue item does not exist"
                     },
                     "409": {
-                        "description": "Conflict"
+                        "description": "Conflict — lastUpdateTime mismatch or concurrent update detected"
                     },
                     "500": {
                         "description": "Internal server error"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -729,6 +729,59 @@
                         "description": "Internal server error"
                     }
                 }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Applies a partial update to a catalogue item. Only fields present in the JSON body are modified.\nRequired: lastUpdateTime (for conflict detection). Supported keys: name, catalogueNumber, description, manufacturerUrl, manufacturerNumber, supplier, category, details.\nScalar fields set to JSON null are cleared. Missing keys are left untouched. Details are merged (no deletion); send value:null to clear a single detail's value.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Catalogue"
+                ],
+                "summary": "Partially update catalogue item",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Catalogue item UID",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Partial catalogue item payload",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CatalogueItem"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "409": {
+                        "description": "Conflict"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
             }
         },
         "/v1/catalogue/item/{uid}/image": {

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2188,6 +2188,43 @@ paths:
       summary: Get catalogue item detail
       tags:
       - Catalogue
+    patch:
+      consumes:
+      - application/json
+      description: |-
+        Applies a partial update to a catalogue item. Only fields present in the JSON body are modified.
+        Required: lastUpdateTime (for conflict detection). Supported keys: name, catalogueNumber, description, manufacturerUrl, manufacturerNumber, supplier, category, details.
+        Scalar fields set to JSON null are cleared. Missing keys are left untouched. Details are merged (no deletion); send value:null to clear a single detail's value.
+      parameters:
+      - description: Catalogue item UID
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Partial catalogue item payload
+        in: body
+        name: body
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CatalogueItem'
+        "400":
+          description: Bad Request
+        "409":
+          description: Conflict
+        "500":
+          description: Internal server error
+      security:
+      - BearerAuth: []
+      summary: Partially update catalogue item
+      tags:
+      - Catalogue
     put:
       consumes:
       - application/json

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -2215,9 +2215,12 @@ paths:
           schema:
             $ref: '#/definitions/models.CatalogueItem'
         "400":
-          description: Bad Request
+          description: Bad Request — malformed body, missing lastUpdateTime, or unknown
+            supplier/category/property UID
+        "404":
+          description: Not Found — catalogue item does not exist
         "409":
-          description: Conflict
+          description: Conflict — lastUpdateTime mismatch or concurrent update detected
         "500":
           description: Internal server error
       security:

--- a/helpers/change_tracking.go
+++ b/helpers/change_tracking.go
@@ -1,0 +1,96 @@
+package helpers
+
+import (
+	"encoding/json"
+	"reflect"
+)
+
+type ChangeType string
+
+const (
+	ChangeTypeString   ChangeType = "string"
+	ChangeTypeNumber   ChangeType = "number"
+	ChangeTypeBoolean  ChangeType = "boolean"
+	ChangeTypeDate     ChangeType = "date"
+	ChangeTypeCodebook ChangeType = "codebook"
+)
+
+type ChangeEntry struct {
+	Field    string      `json:"field"`
+	Type     string      `json:"type"`
+	OldValue interface{} `json:"oldValue"`
+	NewValue interface{} `json:"newValue"`
+}
+
+// AppendIfChanged appends a ChangeEntry to entries when oldVal and newVal differ.
+// Codebook values are compared by UID field; everything else via reflect.DeepEqual.
+// Typed-nil pointers are normalized to untyped nil in the serialized output.
+func AppendIfChanged(entries []ChangeEntry, field string, t ChangeType, oldVal, newVal interface{}) []ChangeEntry {
+	if valuesEqual(t, oldVal, newVal) {
+		return entries
+	}
+	return append(entries, ChangeEntry{
+		Field:    field,
+		Type:     string(t),
+		OldValue: normalizeNil(oldVal),
+		NewValue: normalizeNil(newVal),
+	})
+}
+
+// MarshalChanges serializes a ChangeEntry slice to the JSON string format
+// stored on WAS_UPDATED_BY.changes. An empty/nil slice yields "[]".
+func MarshalChanges(entries []ChangeEntry) string {
+	if entries == nil {
+		return "[]"
+	}
+	b, err := json.Marshal(entries)
+	if err != nil {
+		return "[]"
+	}
+	return string(b)
+}
+
+func valuesEqual(t ChangeType, a, b interface{}) bool {
+	aNil, bNil := isNil(a), isNil(b)
+	if aNil && bNil {
+		return true
+	}
+	if aNil != bNil {
+		return false
+	}
+	if t == ChangeTypeCodebook {
+		return codebookUID(a) == codebookUID(b)
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+func isNil(v interface{}) bool {
+	if v == nil {
+		return true
+	}
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Ptr, reflect.Map, reflect.Slice, reflect.Chan, reflect.Func, reflect.Interface:
+		return rv.IsNil()
+	}
+	return false
+}
+
+func normalizeNil(v interface{}) interface{} {
+	if isNil(v) {
+		return nil
+	}
+	return v
+}
+
+func codebookUID(v interface{}) string {
+	rv := reflect.Indirect(reflect.ValueOf(v))
+	if !rv.IsValid() || rv.Kind() != reflect.Struct {
+		return ""
+	}
+	f := rv.FieldByName("UID")
+	if !f.IsValid() || f.Kind() != reflect.String {
+		return ""
+	}
+	return f.String()
+}

--- a/helpers/change_tracking_test.go
+++ b/helpers/change_tracking_test.go
@@ -1,0 +1,120 @@
+package helpers
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	codebookModels "panda/apigateway/services/codebook-service/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAppendIfChanged_SameValue_NoAppend(t *testing.T) {
+	entries := []ChangeEntry{}
+	entries = AppendIfChanged(entries, "name", ChangeTypeString, "foo", "foo")
+	assert.Empty(t, entries)
+}
+
+func TestAppendIfChanged_DifferentString(t *testing.T) {
+	entries := AppendIfChanged(nil, "name", ChangeTypeString, "old", "new")
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "name", entries[0].Field)
+	assert.Equal(t, "string", entries[0].Type)
+	assert.Equal(t, "old", entries[0].OldValue)
+	assert.Equal(t, "new", entries[0].NewValue)
+}
+
+func TestAppendIfChanged_NilOldNonNilNew(t *testing.T) {
+	var oldVal *string
+	newVal := "new"
+	entries := AppendIfChanged(nil, "description", ChangeTypeString, oldVal, &newVal)
+	assert.Len(t, entries, 1)
+	assert.Nil(t, entries[0].OldValue)
+	assert.NotNil(t, entries[0].NewValue)
+}
+
+func TestAppendIfChanged_NonNilOldNilNew(t *testing.T) {
+	oldVal := "old"
+	var newVal *string
+	entries := AppendIfChanged(nil, "description", ChangeTypeString, &oldVal, newVal)
+	assert.Len(t, entries, 1)
+	assert.NotNil(t, entries[0].OldValue)
+	assert.Nil(t, entries[0].NewValue)
+}
+
+func TestAppendIfChanged_BothNil_NoAppend(t *testing.T) {
+	var oldVal, newVal *string
+	entries := AppendIfChanged(nil, "description", ChangeTypeString, oldVal, newVal)
+	assert.Empty(t, entries)
+}
+
+func TestAppendIfChanged_Codebook_SameUID_DifferentName_NoAppend(t *testing.T) {
+	oldVal := &codebookModels.Codebook{UID: "abc-123", Name: "Old Name"}
+	newVal := &codebookModels.Codebook{UID: "abc-123", Name: "New Name"}
+	entries := AppendIfChanged(nil, "supplier", ChangeTypeCodebook, oldVal, newVal)
+	assert.Empty(t, entries, "same UID should not register as a change even when Name differs")
+}
+
+func TestAppendIfChanged_Codebook_DifferentUID(t *testing.T) {
+	oldVal := &codebookModels.Codebook{UID: "abc-123", Name: "Supplier A"}
+	newVal := &codebookModels.Codebook{UID: "xyz-789", Name: "Supplier B"}
+	entries := AppendIfChanged(nil, "supplier", ChangeTypeCodebook, oldVal, newVal)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, "codebook", entries[0].Type)
+}
+
+func TestAppendIfChanged_Codebook_NilToValue(t *testing.T) {
+	var oldVal *codebookModels.Codebook
+	newVal := &codebookModels.Codebook{UID: "abc", Name: "X"}
+	entries := AppendIfChanged(nil, "supplier", ChangeTypeCodebook, oldVal, newVal)
+	assert.Len(t, entries, 1)
+	assert.Nil(t, entries[0].OldValue)
+	assert.NotNil(t, entries[0].NewValue)
+}
+
+func TestAppendIfChanged_AllChangeTypes(t *testing.T) {
+	now := time.Now()
+	later := now.Add(time.Hour)
+
+	cases := []struct {
+		name     string
+		typ      ChangeType
+		old, new interface{}
+	}{
+		{"string", ChangeTypeString, "a", "b"},
+		{"number", ChangeTypeNumber, float64(1), float64(2)},
+		{"boolean", ChangeTypeBoolean, true, false},
+		{"date", ChangeTypeDate, now, later},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			entries := AppendIfChanged(nil, "f", c.typ, c.old, c.new)
+			assert.Len(t, entries, 1)
+			assert.Equal(t, string(c.typ), entries[0].Type)
+		})
+	}
+}
+
+func TestMarshalChanges_Empty(t *testing.T) {
+	assert.Equal(t, "[]", MarshalChanges(nil))
+	assert.Equal(t, "[]", MarshalChanges([]ChangeEntry{}))
+}
+
+func TestMarshalChanges_ProducesExpectedShape(t *testing.T) {
+	entries := []ChangeEntry{
+		{Field: "name", Type: "string", OldValue: "old", NewValue: "new"},
+		{Field: "supplier", Type: "codebook", OldValue: nil, NewValue: map[string]string{"uid": "u", "name": "n"}},
+	}
+	out := MarshalChanges(entries)
+
+	var parsed []map[string]interface{}
+	err := json.Unmarshal([]byte(out), &parsed)
+	assert.NoError(t, err)
+	assert.Len(t, parsed, 2)
+	assert.Equal(t, "name", parsed[0]["field"])
+	assert.Equal(t, "string", parsed[0]["type"])
+	assert.Equal(t, "old", parsed[0]["oldValue"])
+	assert.Equal(t, "new", parsed[0]["newValue"])
+	assert.Nil(t, parsed[1]["oldValue"])
+}

--- a/helpers/database.go
+++ b/helpers/database.go
@@ -343,6 +343,9 @@ func GetNeo4jSingleRecordAndMapToStruct[T any](session neo4j.Session, query Data
 
 		record, err := result.Single()
 		if err != nil {
+			if isNoRowsError(err) {
+				return nil, ERR_NO_ROWS
+			}
 			return nil, fmt.Errorf(err.Error())
 		}
 
@@ -367,6 +370,9 @@ func GetNeo4jSingleRecordSingleValue[T any](session neo4j.Session, query Databas
 
 		record, err := result.Single()
 		if err != nil {
+			if isNoRowsError(err) {
+				return nil, ERR_NO_ROWS
+			}
 			return nil, fmt.Errorf(err.Error())
 		}
 
@@ -418,6 +424,9 @@ func WriteNeo4jAndReturnSingleValue[T any](session neo4j.Session, query Database
 
 		record, err := result.Single()
 		if err != nil {
+			if isNoRowsError(err) {
+				return nil, ERR_NO_ROWS
+			}
 			return nil, fmt.Errorf(err.Error())
 		}
 
@@ -1054,3 +1063,16 @@ var ERR_DELETE_RELATED_ITEMS = errors.New("DELETE_NOT_POSSIBLE_RELATED_ITEMS")
 var ERR_CONFLICT = errors.New("CONFLICT")
 var ERR_DUPLICATE_SYSTEM_CODE = errors.New("DUPLICATE_SYSTEM_CODE")
 var ERR_MISSING_REQUIRED_FIELD = errors.New("MISSING_REQUIRED_FIELD")
+
+// ERR_NO_ROWS is returned by the single-record neo4j helpers when Result.Single()
+// reports zero matching rows. The error text preserves the driver's original message
+// so existing callers that do strings.Contains(err.Error(), "no more records")
+// keep working; new callers should prefer errors.Is(err, helpers.ERR_NO_ROWS).
+var ERR_NO_ROWS = errors.New("Result contains no more records")
+
+// isNoRowsError detects the neo4j driver's "no more records" UsageError that
+// Result.Single() emits when a query returns zero rows. Used by the single-record
+// helpers to convert the driver's stringy error into our typed ERR_NO_ROWS sentinel.
+func isNoRowsError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "no more records")
+}

--- a/helpers/database.go
+++ b/helpers/database.go
@@ -162,6 +162,9 @@ func GetSingleNode(session neo4j.Session, node interface{}) (err error) {
 
 		record, err := result.Single()
 		if err != nil {
+			if isNoRowsError(err) {
+				return nil, ERR_NO_ROWS
+			}
 			return nil, err
 		}
 
@@ -400,6 +403,9 @@ func WriteNeo4jReturnSingleRecordAndMapToStruct[T any](session neo4j.Session, qu
 
 		record, err := result.Single()
 		if err != nil {
+			if isNoRowsError(err) {
+				return nil, ERR_NO_ROWS
+			}
 			return nil, err
 		}
 

--- a/helpers/database.go
+++ b/helpers/database.go
@@ -162,7 +162,7 @@ func GetSingleNode(session neo4j.Session, node interface{}) (err error) {
 
 		record, err := result.Single()
 		if err != nil {
-			return nil, fmt.Errorf(err.Error())
+			return nil, err
 		}
 
 		rec, _ := record.Get("n")
@@ -346,7 +346,7 @@ func GetNeo4jSingleRecordAndMapToStruct[T any](session neo4j.Session, query Data
 			if isNoRowsError(err) {
 				return nil, ERR_NO_ROWS
 			}
-			return nil, fmt.Errorf(err.Error())
+			return nil, err
 		}
 
 		rec, _ := record.Get(query.ReturnAlias)
@@ -373,7 +373,7 @@ func GetNeo4jSingleRecordSingleValue[T any](session neo4j.Session, query Databas
 			if isNoRowsError(err) {
 				return nil, ERR_NO_ROWS
 			}
-			return nil, fmt.Errorf(err.Error())
+			return nil, err
 		}
 
 		rec, _ := record.Get(query.ReturnAlias)
@@ -400,7 +400,7 @@ func WriteNeo4jReturnSingleRecordAndMapToStruct[T any](session neo4j.Session, qu
 
 		record, err := result.Single()
 		if err != nil {
-			return nil, fmt.Errorf(err.Error())
+			return nil, err
 		}
 
 		rec, _ := record.Get(query.ReturnAlias)
@@ -427,7 +427,7 @@ func WriteNeo4jAndReturnSingleValue[T any](session neo4j.Session, query Database
 			if isNoRowsError(err) {
 				return nil, ERR_NO_ROWS
 			}
-			return nil, fmt.Errorf(err.Error())
+			return nil, err
 		}
 
 		rec, _ := record.Get(query.ReturnAlias)
@@ -1065,10 +1065,9 @@ var ERR_DUPLICATE_SYSTEM_CODE = errors.New("DUPLICATE_SYSTEM_CODE")
 var ERR_MISSING_REQUIRED_FIELD = errors.New("MISSING_REQUIRED_FIELD")
 
 // ERR_NO_ROWS is returned by the single-record neo4j helpers when Result.Single()
-// reports zero matching rows. The error text preserves the driver's original message
-// so existing callers that do strings.Contains(err.Error(), "no more records")
-// keep working; new callers should prefer errors.Is(err, helpers.ERR_NO_ROWS).
-var ERR_NO_ROWS = errors.New("Result contains no more records")
+// reports zero matching rows. Callers should use errors.Is(err, helpers.ERR_NO_ROWS)
+// rather than string-match the message.
+var ERR_NO_ROWS = errors.New("no matching records")
 
 // isNoRowsError detects the neo4j driver's "no more records" UsageError that
 // Result.Single() emits when a query returns zero rows. Used by the single-record

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -2188,6 +2188,43 @@ paths:
       summary: Get catalogue item detail
       tags:
       - Catalogue
+    patch:
+      consumes:
+      - application/json
+      description: |-
+        Applies a partial update to a catalogue item. Only fields present in the JSON body are modified.
+        Required: lastUpdateTime (for conflict detection). Supported keys: name, catalogueNumber, description, manufacturerUrl, manufacturerNumber, supplier, category, details.
+        Scalar fields set to JSON null are cleared. Missing keys are left untouched. Details are merged (no deletion); send value:null to clear a single detail's value.
+      parameters:
+      - description: Catalogue item UID
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Partial catalogue item payload
+        in: body
+        name: body
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CatalogueItem'
+        "400":
+          description: Bad Request
+        "409":
+          description: Conflict
+        "500":
+          description: Internal server error
+      security:
+      - BearerAuth: []
+      summary: Partially update catalogue item
+      tags:
+      - Catalogue
     put:
       consumes:
       - application/json

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -2215,9 +2215,12 @@ paths:
           schema:
             $ref: '#/definitions/models.CatalogueItem'
         "400":
-          description: Bad Request
+          description: Bad Request — malformed body, missing lastUpdateTime, or unknown
+            supplier/category/property UID
+        "404":
+          description: Not Found — catalogue item does not exist
         "409":
-          description: Conflict
+          description: Conflict — lastUpdateTime mismatch or concurrent update detected
         "500":
           description: Internal server error
       security:

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1060,13 +1060,17 @@ func UpdateCatalogueItemQuery(item *models.CatalogueItem, oldItem *models.Catalo
 // Only fields with non-nil presence markers in `fields` produce SET / MERGE segments.
 // A JSON-serialized changes array is attached to the WAS_UPDATED_BY relationship for audit.
 //
+// Query shape: PHASE 1 matches every referenced node (user, item with lastUpdateTime guard,
+// supplier, category, each detail property), PHASE 2 performs all writes, PHASE 3 writes
+// the audit relationship and returns. This ordering guarantees that if any reference is
+// missing or the timestamp guard fails, the whole query yields zero rows and NO writes
+// execute — not even lastUpdateTime advances. (The write transaction also rolls back on
+// the ERR_NO_ROWS that results, but structuring the query this way makes partial-write
+// safety independent of transaction-scope guarantees.)
+//
 // The item MATCH includes lastUpdateTime as a precondition: concurrent writes that
 // advance the timestamp between service-layer read and this query will make the MATCH
 // return zero rows, causing no writes and a missing-record response the service maps to 409.
-//
-// Relationship swaps (supplier, category) MATCH the new target node BEFORE deleting the
-// existing relationship so an invalid target UID cannot leave the item stripped of
-// supplier/category. The service layer also pre-validates these UIDs to surface 400 errors.
 //
 // Detail audit metadata (field name, type) is sourced from originalItem.Details — which
 // service.GetCatalogueItemWithDetailsByUid augments with the canonical property set of the
@@ -1082,24 +1086,57 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 
 	var changes []helpers.ChangeEntry
 
+	// Track variables that must be carried through subsequent WITH clauses.
+	carry := []string{"u", "item"}
+
+	// =====  PHASE 1 — all MATCHes (validate refs before any write)  =====
+
 	result.Query = `
 	MATCH(u:User{uid: $userUID})
 	WITH u
 	MATCH(item:CatalogueItem{uid: $uid})
 	WHERE item.lastUpdateTime.epochMillis = $lastUpdateTimeMillis
-	SET item.lastUpdateTime = datetime()
-	WITH u, item
 	`
+
+	settingSupplier := fields.Supplier != nil && fields.Supplier.Value != nil && fields.Supplier.Value.UID != ""
+	if settingSupplier {
+		result.Parameters["supplierUid"] = fields.Supplier.Value.UID
+		result.Query += ` WITH ` + strings.Join(carry, ", ") + ` MATCH(newSup:Supplier{uid: $supplierUid}) `
+		carry = append(carry, "newSup")
+	}
+
+	if fields.Category != nil && fields.Category.UID != "" {
+		result.Parameters["categoryUid"] = fields.Category.UID
+		result.Query += ` WITH ` + strings.Join(carry, ", ") + ` MATCH(newCat:CatalogueCategory{uid: $categoryUid}) `
+		carry = append(carry, "newCat")
+	}
+
+	if fields.Details != nil {
+		for i, detail := range *fields.Details {
+			propAlias := fmt.Sprintf("pp%d", i)
+			propUIDKey := fmt.Sprintf("propUID%d", i)
+			result.Parameters[propUIDKey] = detail.Property.UID
+			result.Query += ` WITH ` + strings.Join(carry, ", ") + fmt.Sprintf(` MATCH(%s:CatalogueCategoryProperty{uid: $%s}) `, propAlias, propUIDKey)
+			carry = append(carry, propAlias)
+		}
+	}
+
+	// Consolidating WITH so subsequent clauses see all matched variables.
+	result.Query += ` WITH ` + strings.Join(carry, ", ") + ` `
+
+	// =====  PHASE 2 — all writes  =====
+
+	result.Query += ` SET item.lastUpdateTime = datetime() `
 
 	if fields.Name != nil {
 		result.Parameters["name"] = *fields.Name
-		result.Query += ` SET item.name = $name WITH u, item `
+		result.Query += ` SET item.name = $name `
 		changes = helpers.AppendIfChanged(changes, "name", helpers.ChangeTypeString, originalItem.Name, *fields.Name)
 	}
 
 	if fields.CatalogueNumber != nil {
 		result.Parameters["catalogueNumber"] = *fields.CatalogueNumber
-		result.Query += ` SET item.catalogueNumber = $catalogueNumber WITH u, item `
+		result.Query += ` SET item.catalogueNumber = $catalogueNumber `
 		changes = helpers.AppendIfChanged(changes, "catalogueNumber", helpers.ChangeTypeString, originalItem.CatalogueNumber, *fields.CatalogueNumber)
 	}
 
@@ -1112,7 +1149,7 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 		} else {
 			result.Parameters[paramKey] = nil
 		}
-		result.Query += fmt.Sprintf(` SET item.%s = $%s WITH u, item `, cypherField, paramKey)
+		result.Query += fmt.Sprintf(` SET item.%s = $%s `, cypherField, paramKey)
 		changes = helpers.AppendIfChanged(changes, changeField, helpers.ChangeTypeString, stringPtrToAny(oldVal), stringPtrToAny(opt.Value))
 	}
 
@@ -1121,23 +1158,9 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	applyOptionalString(fields.ManufacturerNumber, "manufacturerNumber", "manufacturerNumber", "manufacturerNumber", originalItem.ManufacturerNumber)
 
 	if fields.Supplier != nil {
-		if fields.Supplier.Value != nil && fields.Supplier.Value.UID != "" {
-			result.Parameters["supplierUid"] = fields.Supplier.Value.UID
-			result.Query += `
-			MATCH(newSup:Supplier{uid: $supplierUid})
-			WITH u, item, newSup
-			OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
-			DELETE oldSup
-			WITH u, item, newSup
-			MERGE(item)-[:HAS_SUPPLIER]->(newSup)
-			WITH u, item
-			`
-		} else {
-			result.Query += `
-			OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
-			DELETE oldSup
-			WITH u, item
-			`
+		result.Query += ` WITH ` + strings.Join(carry, ", ") + ` OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->() DELETE oldSup `
+		if settingSupplier {
+			result.Query += ` WITH ` + strings.Join(carry, ", ") + ` MERGE(item)-[:HAS_SUPPLIER]->(newSup) `
 		}
 		var oldSup, newSup interface{}
 		if originalItem.Supplier != nil {
@@ -1150,31 +1173,20 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	}
 
 	if fields.Category != nil && fields.Category.UID != "" {
-		result.Parameters["categoryUid"] = fields.Category.UID
-		result.Query += `
-		MATCH(newCat:CatalogueCategory{uid: $categoryUid})
-		WITH u, item, newCat
-		OPTIONAL MATCH (item)-[oldCat:BELONGS_TO_CATEGORY]->()
-		DELETE oldCat
-		WITH u, item, newCat
-		MERGE(item)-[:BELONGS_TO_CATEGORY]->(newCat)
-		WITH u, item
-		`
+		result.Query += ` WITH ` + strings.Join(carry, ", ") + ` OPTIONAL MATCH (item)-[oldCat:BELONGS_TO_CATEGORY]->() DELETE oldCat `
+		result.Query += ` WITH ` + strings.Join(carry, ", ") + ` MERGE(item)-[:BELONGS_TO_CATEGORY]->(newCat) `
 		changes = helpers.AppendIfChanged(changes, "category", helpers.ChangeTypeCodebook, originalItem.Category, *fields.Category)
 	}
 
 	if fields.Details != nil {
 		for i, detail := range *fields.Details {
 			propAlias := fmt.Sprintf("pp%d", i)
-			propUIDKey := fmt.Sprintf("propUID%d", i)
 			propValKey := fmt.Sprintf("propValue%d", i)
-
-			result.Parameters[propUIDKey] = detail.Property.UID
 
 			oldDetail := findDetailByPropUID(originalItem.Details, detail.Property.UID)
 
-			// Source type code from DB (originalItem) to prevent audit spoofing.
-			// Fall back to payload if not found (service layer rejects unknown UIDs).
+			// Source name/type from DB (originalItem) to prevent audit spoofing.
+			// Fall back to payload if not found (service layer rejects unknown UIDs upstream).
 			typeCode := detail.Property.Type.Code
 			propName := detail.Property.Name
 			if oldDetail != nil {
@@ -1189,12 +1201,7 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 			newStored := encodeDetailValueForStorage(detail.Value, typeCode)
 			result.Parameters[propValKey] = newStored
 
-			result.Query += fmt.Sprintf(`
-			MATCH(%[1]s:CatalogueCategoryProperty{uid: $%[2]s})
-			MERGE(item)-[r_%[1]s:HAS_CATALOGUE_PROPERTY]->(%[1]s)
-			SET r_%[1]s.value = $%[3]s
-			WITH u, item
-			`, propAlias, propUIDKey, propValKey)
+			result.Query += fmt.Sprintf(` MERGE(item)-[r_%[1]s:HAS_CATALOGUE_PROPERTY]->(%[1]s) SET r_%[1]s.value = $%[2]s `, propAlias, propValKey)
 
 			// Normalize both sides to the DB storage form so type mismatches
 			// (e.g. payload int 50 vs stored string "50") don't register as changes.
@@ -1207,6 +1214,8 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 			changes = helpers.AppendIfChanged(changes, propName, changeType, oldForCompare, newForCompare)
 		}
 	}
+
+	// =====  PHASE 3 — audit relationship + return  =====
 
 	result.Parameters["changes"] = helpers.MarshalChanges(changes)
 	result.Query += `

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1207,11 +1207,14 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 
 			result.Query += fmt.Sprintf(` MERGE(item)-[r_%[1]s:HAS_CATALOGUE_PROPERTY]->(%[1]s) SET r_%[1]s.value = $%[2]s `, propAlias, propValKey)
 
-			// Normalize both sides to the DB storage form so type mismatches
-			// (e.g. payload int 50 vs stored string "50") don't register as changes.
+			// Normalize both sides through encodeDetailValueForStorage so type mismatches
+			// don't register as changes:
+			//   - payload int 50 vs stored string "50"
+			//   - range re-read as RangeFloat64Nullable struct vs re-marshaled JSON string
+			//   - map[string]interface{} from FE vs struct from DB read
 			var oldForCompare interface{}
 			if oldDetail != nil {
-				oldForCompare = oldDetail.Value
+				oldForCompare = encodeDetailValueForStorage(oldDetail.Value, typeCode)
 			}
 			newForCompare := newStored
 			changeType := mapPropertyTypeToChangeType(typeCode)
@@ -1232,8 +1235,10 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 }
 
 // encodeDetailValueForStorage normalizes a detail value to the string representation
-// the DB stores for HAS_CATALOGUE_PROPERTY.value. range → JSON-stringified map, nil → nil,
-// everything else → fmt.Sprintf("%v", v) which matches Neo4j's toString() for numbers/bools.
+// the DB stores for HAS_CATALOGUE_PROPERTY.value. range → canonical JSON via
+// helpers.RangeFloat64Nullable (fixed key order regardless of input shape — map, struct,
+// or pre-marshaled string), nil → nil, everything else → fmt.Sprintf("%v", v) which
+// matches Neo4j's toString() for numbers/bools.
 func encodeDetailValueForStorage(value interface{}, typeCode string) interface{} {
 	if value == nil {
 		return nil
@@ -1242,12 +1247,33 @@ func encodeDetailValueForStorage(value interface{}, typeCode string) interface{}
 		return ""
 	}
 	if typeCode == "range" {
-		if b, err := json.Marshal(value); err == nil {
+		r := coerceToRange(value)
+		if b, err := json.Marshal(r); err == nil {
 			return string(b)
 		}
 		return value
 	}
 	return fmt.Sprintf("%v", value)
+}
+
+// coerceToRange maps heterogeneous inputs into the canonical helpers.RangeFloat64Nullable
+// shape so both sides of a change comparison produce byte-identical JSON.
+// Handles: already-canonical struct (re-read via GetCatalogueItemWithDetailsByUid),
+// JSON string (raw DB storage form), and map[string]interface{} (FE payload).
+func coerceToRange(v interface{}) helpers.RangeFloat64Nullable {
+	var r helpers.RangeFloat64Nullable
+	switch x := v.(type) {
+	case helpers.RangeFloat64Nullable:
+		return x
+	case string:
+		_ = json.Unmarshal([]byte(x), &r)
+		return r
+	default:
+		if b, err := json.Marshal(v); err == nil {
+			_ = json.Unmarshal(b, &r)
+		}
+		return r
+	}
 }
 
 func stringPtrToAny(s *string) interface{} {

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1059,11 +1059,26 @@ func UpdateCatalogueItemQuery(item *models.CatalogueItem, oldItem *models.Catalo
 // PatchCatalogueItemQuery builds a partial-update Cypher query for a catalogue item.
 // Only fields with non-nil presence markers in `fields` produce SET / MERGE segments.
 // A JSON-serialized changes array is attached to the WAS_UPDATED_BY relationship for audit.
+//
+// The item MATCH includes lastUpdateTime as a precondition: concurrent writes that
+// advance the timestamp between service-layer read and this query will make the MATCH
+// return zero rows, causing no writes and a missing-record response the service maps to 409.
+//
+// Relationship swaps (supplier, category) MATCH the new target node BEFORE deleting the
+// existing relationship so an invalid target UID cannot leave the item stripped of
+// supplier/category. The service layer also pre-validates these UIDs to surface 400 errors.
+//
+// Detail audit metadata (field name, type) is sourced from originalItem.Details — which
+// service.GetCatalogueItemWithDetailsByUid augments with the canonical property set of the
+// item's category — so payload-supplied Property.Name/Type.Code cannot spoof the audit log.
+// Unknown property UIDs fall back to the payload (and the service layer rejects them).
 func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem, userUID string) (result helpers.DatabaseQuery) {
 
 	result.Parameters = make(map[string]interface{})
 	result.Parameters["uid"] = uid
 	result.Parameters["userUID"] = userUID
+	// epoch millis avoids time.Time → Neo4j DateTime precision/timezone round-trip mismatches
+	result.Parameters["lastUpdateTimeMillis"] = originalItem.LastUpdateTime.UnixMilli()
 
 	var changes []helpers.ChangeEntry
 
@@ -1071,6 +1086,7 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	MATCH(u:User{uid: $userUID})
 	WITH u
 	MATCH(item:CatalogueItem{uid: $uid})
+	WHERE item.lastUpdateTime.epochMillis = $lastUpdateTimeMillis
 	SET item.lastUpdateTime = datetime()
 	WITH u, item
 	`
@@ -1105,16 +1121,21 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	applyOptionalString(fields.ManufacturerNumber, "manufacturerNumber", "manufacturerNumber", "manufacturerNumber", originalItem.ManufacturerNumber)
 
 	if fields.Supplier != nil {
-		result.Query += `
-		OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
-		DELETE oldSup
-		WITH u, item
-		`
 		if fields.Supplier.Value != nil && fields.Supplier.Value.UID != "" {
 			result.Parameters["supplierUid"] = fields.Supplier.Value.UID
 			result.Query += `
 			MATCH(newSup:Supplier{uid: $supplierUid})
+			WITH u, item, newSup
+			OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
+			DELETE oldSup
+			WITH u, item, newSup
 			MERGE(item)-[:HAS_SUPPLIER]->(newSup)
+			WITH u, item
+			`
+		} else {
+			result.Query += `
+			OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
+			DELETE oldSup
 			WITH u, item
 			`
 		}
@@ -1131,10 +1152,11 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	if fields.Category != nil && fields.Category.UID != "" {
 		result.Parameters["categoryUid"] = fields.Category.UID
 		result.Query += `
+		MATCH(newCat:CatalogueCategory{uid: $categoryUid})
+		WITH u, item, newCat
 		OPTIONAL MATCH (item)-[oldCat:BELONGS_TO_CATEGORY]->()
 		DELETE oldCat
-		WITH u, item
-		MATCH(newCat:CatalogueCategory{uid: $categoryUid})
+		WITH u, item, newCat
 		MERGE(item)-[:BELONGS_TO_CATEGORY]->(newCat)
 		WITH u, item
 		`
@@ -1149,21 +1171,23 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 
 			result.Parameters[propUIDKey] = detail.Property.UID
 
-			newValForChange := detail.Value
-			if detail.Value == nil {
-				result.Parameters[propValKey] = nil
-			} else {
-				if detail.Property.Type.Code == "range" {
-					if jsonValue, err := json.Marshal(detail.Value); err == nil {
-						result.Parameters[propValKey] = string(jsonValue)
-						newValForChange = string(jsonValue)
-					} else {
-						result.Parameters[propValKey] = detail.Value
-					}
-				} else {
-					result.Parameters[propValKey] = detail.Value
+			oldDetail := findDetailByPropUID(originalItem.Details, detail.Property.UID)
+
+			// Source type code from DB (originalItem) to prevent audit spoofing.
+			// Fall back to payload if not found (service layer rejects unknown UIDs).
+			typeCode := detail.Property.Type.Code
+			propName := detail.Property.Name
+			if oldDetail != nil {
+				if oldDetail.Property.Type.Code != "" {
+					typeCode = oldDetail.Property.Type.Code
+				}
+				if oldDetail.Property.Name != "" {
+					propName = oldDetail.Property.Name
 				}
 			}
+
+			newStored := encodeDetailValueForStorage(detail.Value, typeCode)
+			result.Parameters[propValKey] = newStored
 
 			result.Query += fmt.Sprintf(`
 			MATCH(%[1]s:CatalogueCategoryProperty{uid: $%[2]s})
@@ -1172,17 +1196,15 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 			WITH u, item
 			`, propAlias, propUIDKey, propValKey)
 
-			changeType := mapPropertyTypeToChangeType(detail.Property.Type.Code)
-			oldDetail := findDetailByPropUID(originalItem.Details, detail.Property.UID)
-			propName := detail.Property.Name
-			var oldValForChange interface{}
+			// Normalize both sides to the DB storage form so type mismatches
+			// (e.g. payload int 50 vs stored string "50") don't register as changes.
+			var oldForCompare interface{}
 			if oldDetail != nil {
-				oldValForChange = oldDetail.Value
-				if oldDetail.Property.Name != "" {
-					propName = oldDetail.Property.Name
-				}
+				oldForCompare = oldDetail.Value
 			}
-			changes = helpers.AppendIfChanged(changes, propName, changeType, oldValForChange, newValForChange)
+			newForCompare := newStored
+			changeType := mapPropertyTypeToChangeType(typeCode)
+			changes = helpers.AppendIfChanged(changes, propName, changeType, oldForCompare, newForCompare)
 		}
 	}
 
@@ -1194,6 +1216,25 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 
 	result.ReturnAlias = "uid"
 	return result
+}
+
+// encodeDetailValueForStorage normalizes a detail value to the string representation
+// the DB stores for HAS_CATALOGUE_PROPERTY.value. range → JSON-stringified map, nil → nil,
+// everything else → fmt.Sprintf("%v", v) which matches Neo4j's toString() for numbers/bools.
+func encodeDetailValueForStorage(value interface{}, typeCode string) interface{} {
+	if value == nil {
+		return nil
+	}
+	if s, ok := value.(string); ok && s == "" {
+		return ""
+	}
+	if typeCode == "range" {
+		if b, err := json.Marshal(value); err == nil {
+			return string(b)
+		}
+		return value
+	}
+	return fmt.Sprintf("%v", value)
 }
 
 func stringPtrToAny(s *string) interface{} {

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1081,8 +1081,11 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	result.Parameters = make(map[string]interface{})
 	result.Parameters["uid"] = uid
 	result.Parameters["userUID"] = userUID
-	// epoch millis avoids time.Time → Neo4j DateTime precision/timezone round-trip mismatches
-	result.Parameters["lastUpdateTimeMillis"] = originalItem.LastUpdateTime.UnixMilli()
+	// Neo4j datetime() has nanosecond precision; epochMillis alone would truncate
+	// sub-millisecond differences and let concurrent writes inside the same ms race through.
+	// Compare epochSeconds + nanosecond (0-999_999_999 within the second) for full precision.
+	result.Parameters["lastUpdateTimeEpochSeconds"] = originalItem.LastUpdateTime.Unix()
+	result.Parameters["lastUpdateTimeNanosecond"] = originalItem.LastUpdateTime.Nanosecond()
 
 	var changes []helpers.ChangeEntry
 
@@ -1095,7 +1098,8 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 	MATCH(u:User{uid: $userUID})
 	WITH u
 	MATCH(item:CatalogueItem{uid: $uid})
-	WHERE item.lastUpdateTime.epochMillis = $lastUpdateTimeMillis
+	WHERE item.lastUpdateTime.epochSeconds = $lastUpdateTimeEpochSeconds
+	  AND item.lastUpdateTime.nanosecond = $lastUpdateTimeNanosecond
 	`
 
 	settingSupplier := fields.Supplier != nil && fields.Supplier.Value != nil && fields.Supplier.Value.UID != ""

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1210,7 +1210,7 @@ func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields
 
 	result.Parameters["changes"] = helpers.MarshalChanges(changes)
 	result.Query += `
-	CREATE(item)-[:WAS_UPDATED_BY{ at: datetime(), action: "PATCH", changes: $changes }]->(u)
+	CREATE(item)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE", changes: $changes }]->(u)
 	RETURN item.uid as uid
 	`
 

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -1056,6 +1056,175 @@ func UpdateCatalogueItemQuery(item *models.CatalogueItem, oldItem *models.Catalo
 	return result
 }
 
+// PatchCatalogueItemQuery builds a partial-update Cypher query for a catalogue item.
+// Only fields with non-nil presence markers in `fields` produce SET / MERGE segments.
+// A JSON-serialized changes array is attached to the WAS_UPDATED_BY relationship for audit.
+func PatchCatalogueItemQuery(uid string, fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem, userUID string) (result helpers.DatabaseQuery) {
+
+	result.Parameters = make(map[string]interface{})
+	result.Parameters["uid"] = uid
+	result.Parameters["userUID"] = userUID
+
+	var changes []helpers.ChangeEntry
+
+	result.Query = `
+	MATCH(u:User{uid: $userUID})
+	WITH u
+	MATCH(item:CatalogueItem{uid: $uid})
+	SET item.lastUpdateTime = datetime()
+	WITH u, item
+	`
+
+	if fields.Name != nil {
+		result.Parameters["name"] = *fields.Name
+		result.Query += ` SET item.name = $name WITH u, item `
+		changes = helpers.AppendIfChanged(changes, "name", helpers.ChangeTypeString, originalItem.Name, *fields.Name)
+	}
+
+	if fields.CatalogueNumber != nil {
+		result.Parameters["catalogueNumber"] = *fields.CatalogueNumber
+		result.Query += ` SET item.catalogueNumber = $catalogueNumber WITH u, item `
+		changes = helpers.AppendIfChanged(changes, "catalogueNumber", helpers.ChangeTypeString, originalItem.CatalogueNumber, *fields.CatalogueNumber)
+	}
+
+	applyOptionalString := func(opt *models.Optional[string], paramKey, cypherField, changeField string, oldVal *string) {
+		if opt == nil {
+			return
+		}
+		if opt.Value != nil {
+			result.Parameters[paramKey] = *opt.Value
+		} else {
+			result.Parameters[paramKey] = nil
+		}
+		result.Query += fmt.Sprintf(` SET item.%s = $%s WITH u, item `, cypherField, paramKey)
+		changes = helpers.AppendIfChanged(changes, changeField, helpers.ChangeTypeString, stringPtrToAny(oldVal), stringPtrToAny(opt.Value))
+	}
+
+	applyOptionalString(fields.Description, "description", "description", "description", originalItem.Description)
+	applyOptionalString(fields.ManufacturerUrl, "manufacturerUrl", "manufacturerUrl", "manufacturerUrl", originalItem.ManufacturerUrl)
+	applyOptionalString(fields.ManufacturerNumber, "manufacturerNumber", "manufacturerNumber", "manufacturerNumber", originalItem.ManufacturerNumber)
+
+	if fields.Supplier != nil {
+		result.Query += `
+		OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()
+		DELETE oldSup
+		WITH u, item
+		`
+		if fields.Supplier.Value != nil && fields.Supplier.Value.UID != "" {
+			result.Parameters["supplierUid"] = fields.Supplier.Value.UID
+			result.Query += `
+			MATCH(newSup:Supplier{uid: $supplierUid})
+			MERGE(item)-[:HAS_SUPPLIER]->(newSup)
+			WITH u, item
+			`
+		}
+		var oldSup, newSup interface{}
+		if originalItem.Supplier != nil {
+			oldSup = originalItem.Supplier
+		}
+		if fields.Supplier.Value != nil {
+			newSup = fields.Supplier.Value
+		}
+		changes = helpers.AppendIfChanged(changes, "supplier", helpers.ChangeTypeCodebook, oldSup, newSup)
+	}
+
+	if fields.Category != nil && fields.Category.UID != "" {
+		result.Parameters["categoryUid"] = fields.Category.UID
+		result.Query += `
+		OPTIONAL MATCH (item)-[oldCat:BELONGS_TO_CATEGORY]->()
+		DELETE oldCat
+		WITH u, item
+		MATCH(newCat:CatalogueCategory{uid: $categoryUid})
+		MERGE(item)-[:BELONGS_TO_CATEGORY]->(newCat)
+		WITH u, item
+		`
+		changes = helpers.AppendIfChanged(changes, "category", helpers.ChangeTypeCodebook, originalItem.Category, *fields.Category)
+	}
+
+	if fields.Details != nil {
+		for i, detail := range *fields.Details {
+			propAlias := fmt.Sprintf("pp%d", i)
+			propUIDKey := fmt.Sprintf("propUID%d", i)
+			propValKey := fmt.Sprintf("propValue%d", i)
+
+			result.Parameters[propUIDKey] = detail.Property.UID
+
+			newValForChange := detail.Value
+			if detail.Value == nil {
+				result.Parameters[propValKey] = nil
+			} else {
+				if detail.Property.Type.Code == "range" {
+					if jsonValue, err := json.Marshal(detail.Value); err == nil {
+						result.Parameters[propValKey] = string(jsonValue)
+						newValForChange = string(jsonValue)
+					} else {
+						result.Parameters[propValKey] = detail.Value
+					}
+				} else {
+					result.Parameters[propValKey] = detail.Value
+				}
+			}
+
+			result.Query += fmt.Sprintf(`
+			MATCH(%[1]s:CatalogueCategoryProperty{uid: $%[2]s})
+			MERGE(item)-[r_%[1]s:HAS_CATALOGUE_PROPERTY]->(%[1]s)
+			SET r_%[1]s.value = $%[3]s
+			WITH u, item
+			`, propAlias, propUIDKey, propValKey)
+
+			changeType := mapPropertyTypeToChangeType(detail.Property.Type.Code)
+			oldDetail := findDetailByPropUID(originalItem.Details, detail.Property.UID)
+			propName := detail.Property.Name
+			var oldValForChange interface{}
+			if oldDetail != nil {
+				oldValForChange = oldDetail.Value
+				if oldDetail.Property.Name != "" {
+					propName = oldDetail.Property.Name
+				}
+			}
+			changes = helpers.AppendIfChanged(changes, propName, changeType, oldValForChange, newValForChange)
+		}
+	}
+
+	result.Parameters["changes"] = helpers.MarshalChanges(changes)
+	result.Query += `
+	CREATE(item)-[:WAS_UPDATED_BY{ at: datetime(), action: "PATCH", changes: $changes }]->(u)
+	RETURN item.uid as uid
+	`
+
+	result.ReturnAlias = "uid"
+	return result
+}
+
+func stringPtrToAny(s *string) interface{} {
+	if s == nil {
+		return nil
+	}
+	return *s
+}
+
+func mapPropertyTypeToChangeType(code string) helpers.ChangeType {
+	switch code {
+	case "number":
+		return helpers.ChangeTypeNumber
+	case "date":
+		return helpers.ChangeTypeDate
+	case "boolean":
+		return helpers.ChangeTypeBoolean
+	default:
+		return helpers.ChangeTypeString
+	}
+}
+
+func findDetailByPropUID(details []models.CatalogueItemDetail, propUID string) *models.CatalogueItemDetail {
+	for i := range details {
+		if details[i].Property.UID == propUID {
+			return &details[i]
+		}
+	}
+	return nil
+}
+
 // delete catalogue item query
 func DeleteCatalogueItemQuery(itemUid string, userUID string) (result helpers.DatabaseQuery) {
 

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -270,6 +270,53 @@ func TestPatchCatalogueItemQuery_AuditUsesDBSourcedMetadata(t *testing.T) {
 	assert.Equal(t, "number", changes[0]["type"], "type should come from originalItem's Type.Code, not payload")
 }
 
+func TestPatchCatalogueItemQuery_DetailFloatFormatEdgeCases(t *testing.T) {
+	// Pin the encodeDetailValueForStorage behavior for tricky float formats so a future
+	// change doesn't silently alter how numbers are stored / compared.
+	cases := []struct {
+		name     string
+		oldValue interface{}
+		newValue interface{}
+		expected string
+		changed  bool
+	}{
+		{"integer float matches integer string", "1", float64(1), "1", false},
+		{"integer float with trailing .0", "1.0", float64(1), "1", true}, // drift: stored as "1.0", payload normalizes to "1"
+		{"decimal preserves precision", "3.14", float64(3.14), "3.14", false},
+		{"large int-valued float uses exp notation", "1e+20", float64(1e20), "1e+20", false},
+		{"negative", "-2.5", float64(-2.5), "-2.5", false},
+		{"bool true", "true", true, "true", false},
+		{"bool false", "false", false, "false", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			orig := newOriginalItem()
+			// override prop-B's stored value for this case
+			for i := range orig.Details {
+				if orig.Details[i].Property.UID == "prop-B" {
+					orig.Details[i].Value = tc.oldValue
+				}
+			}
+
+			details := []models.CatalogueItemDetail{{
+				Property: models.CatalogueCategoryProperty{UID: "prop-B"},
+				Value:    tc.newValue,
+			}}
+			q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{Details: &details}, orig, "user-1")
+
+			assert.Equal(t, tc.expected, q.Parameters["propValue0"], "stored form must match expected normalized output")
+
+			changes := parseChanges(t, q)
+			if tc.changed {
+				assert.Len(t, changes, 1, "expected value drift to register as a change")
+			} else {
+				assert.Len(t, changes, 0, "semantically equal old/new should not register a change")
+			}
+		})
+	}
+}
+
 func TestPatchCatalogueItemQuery_DetailNumberTypeCoercion(t *testing.T) {
 	// originalItem has prop-B (Weight, type "number") stored as string "50".
 	// Payload sends JSON number 50 (float64 in Go) → should NOT register as change.

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -219,9 +219,13 @@ func TestPatchCatalogueItemQuery_AlwaysSetsLastUpdateAndAuditRel(t *testing.T) {
 func TestPatchCatalogueItemQuery_ItemMatchGuardsLastUpdateTime(t *testing.T) {
 	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{}, newOriginalItem(), "user-1")
 
-	assert.Contains(t, q.Query, "WHERE item.lastUpdateTime.epochMillis = $lastUpdateTimeMillis",
-		"MATCH should include lastUpdateTime precondition to defend against TOCTOU races")
-	assert.Equal(t, newOriginalItem().LastUpdateTime.UnixMilli(), q.Parameters["lastUpdateTimeMillis"])
+	assert.Contains(t, q.Query, "WHERE item.lastUpdateTime.epochSeconds = $lastUpdateTimeEpochSeconds",
+		"MATCH should guard with epochSeconds precondition")
+	assert.Contains(t, q.Query, "AND item.lastUpdateTime.nanosecond = $lastUpdateTimeNanosecond",
+		"MATCH must also compare nanosecond-within-second so sub-millisecond races are caught")
+	original := newOriginalItem()
+	assert.Equal(t, original.LastUpdateTime.Unix(), q.Parameters["lastUpdateTimeEpochSeconds"])
+	assert.Equal(t, original.LastUpdateTime.Nanosecond(), q.Parameters["lastUpdateTimeNanosecond"])
 }
 
 func TestPatchCatalogueItemQuery_SupplierChange_MatchesNewBeforeDelete(t *testing.T) {

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -182,6 +182,29 @@ func TestPatchCatalogueItemQuery_ChangesJsonShape(t *testing.T) {
 	}
 }
 
+func TestPatchCatalogueItemQuery_RangeIdempotent_NoChange(t *testing.T) {
+	// GetCatalogueItemWithDetailsByUid unmarshals stored range JSON into a
+	// helpers.RangeFloat64Nullable struct. If the change comparison didn't normalize
+	// both sides, the struct-vs-string mismatch would register a false-positive change
+	// and break idempotent PATCH for range fields.
+	min, max := 1.0, 10.0
+	orig := newOriginalItem()
+	orig.Details = append(orig.Details, models.CatalogueItemDetail{
+		Property: models.CatalogueCategoryProperty{UID: "prop-range", Name: "Freq", Type: models.CatalogueCategoryPropertyType{Code: "range"}},
+		Value:    helpers.RangeFloat64Nullable{Min: &min, Max: &max},
+	})
+
+	// FE re-sends the same range as a map (how encoding/json unmarshals unknown shapes).
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "prop-range"},
+		Value:    map[string]interface{}{"min": 1.0, "max": 10.0},
+	}}
+	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{Details: &details}, orig, "user-1")
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 0, "idempotent range PATCH must not register a change")
+}
+
 func TestPatchCatalogueItemQuery_DetailRangeValue_SerializesAsJson(t *testing.T) {
 	rangeVal := map[string]interface{}{"min": 1.0, "max": 10.0}
 	details := []models.CatalogueItemDetail{{

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -51,7 +51,7 @@ func TestPatchCatalogueItemQuery_NameOnly(t *testing.T) {
 	assert.NotContains(t, q.Query, "HAS_CATALOGUE_PROPERTY")
 	assert.NotContains(t, q.Query, "HAS_SUPPLIER")
 	assert.NotContains(t, q.Query, "BELONGS_TO_CATEGORY")
-	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Contains(t, q.Query, `action: "UPDATE"`)
 	assert.Contains(t, q.Query, "changes: $changes")
 	assert.Equal(t, "New Name", q.Parameters["name"])
 
@@ -164,7 +164,7 @@ func TestPatchCatalogueItemQuery_NoChanges_EmptyChangesArray(t *testing.T) {
 	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
 
 	assert.Contains(t, q.Query, "SET item.name = $name")
-	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Contains(t, q.Query, `action: "UPDATE"`)
 	assert.Equal(t, "[]", q.Parameters["changes"])
 }
 
@@ -210,7 +210,7 @@ func TestPatchCatalogueItemQuery_AlwaysSetsLastUpdateAndAuditRel(t *testing.T) {
 
 	assert.Contains(t, q.Query, "SET item.lastUpdateTime = datetime()")
 	assert.Contains(t, q.Query, "CREATE(item)-[:WAS_UPDATED_BY")
-	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Contains(t, q.Query, `action: "UPDATE"`)
 	assert.Equal(t, "[]", q.Parameters["changes"])
 	assert.Equal(t, "user-1", q.Parameters["userUID"])
 	assert.Equal(t, "item-1", q.Parameters["uid"])

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -1,0 +1,193 @@
+package catalogueService
+
+import (
+	"encoding/json"
+	"testing"
+
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/catalogue-service/models"
+	codebookModels "panda/apigateway/services/codebook-service/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func ptr[T any](v T) *T { return &v }
+
+func newOriginalItem() *models.CatalogueItem {
+	desc := "old desc"
+	return &models.CatalogueItem{
+		Uid:             "item-1",
+		Name:            "Old Name",
+		CatalogueNumber: "CN-001",
+		Description:     &desc,
+		Category:        codebookModels.Codebook{UID: "cat-old", Name: "Old Cat"},
+		Supplier:        &codebookModels.Codebook{UID: "supp-old", Name: "Old Supp"},
+		Details: []models.CatalogueItemDetail{
+			{Property: models.CatalogueCategoryProperty{UID: "prop-A", Name: "Voltage", Type: models.CatalogueCategoryPropertyType{Code: "text"}}, Value: "12"},
+			{Property: models.CatalogueCategoryProperty{UID: "prop-B", Name: "Weight", Type: models.CatalogueCategoryPropertyType{Code: "number"}}, Value: "50"},
+			{Property: models.CatalogueCategoryProperty{UID: "prop-C", Name: "Note", Type: models.CatalogueCategoryPropertyType{Code: "text"}}, Value: "keep"},
+		},
+	}
+}
+
+func parseChanges(t *testing.T, q helpers.DatabaseQuery) []map[string]interface{} {
+	raw, ok := q.Parameters["changes"].(string)
+	assert.True(t, ok, "changes parameter must be a string")
+	var parsed []map[string]interface{}
+	err := json.Unmarshal([]byte(raw), &parsed)
+	assert.NoError(t, err)
+	return parsed
+}
+
+func TestPatchCatalogueItemQuery_NameOnly(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{Name: ptr("New Name")}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Equal(t, "uid", q.ReturnAlias)
+	assert.Contains(t, q.Query, "SET item.name = $name")
+	assert.NotContains(t, q.Query, "SET item.description")
+	assert.NotContains(t, q.Query, "SET item.catalogueNumber")
+	assert.NotContains(t, q.Query, "HAS_CATALOGUE_PROPERTY")
+	assert.NotContains(t, q.Query, "HAS_SUPPLIER")
+	assert.NotContains(t, q.Query, "BELONGS_TO_CATEGORY")
+	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Contains(t, q.Query, "changes: $changes")
+	assert.Equal(t, "New Name", q.Parameters["name"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "name", changes[0]["field"])
+	assert.Equal(t, "string", changes[0]["type"])
+	assert.Equal(t, "Old Name", changes[0]["oldValue"])
+	assert.Equal(t, "New Name", changes[0]["newValue"])
+}
+
+func TestPatchCatalogueItemQuery_DescriptionNull(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{Description: &models.Optional[string]{Value: nil}}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "SET item.description = $description")
+	assert.Nil(t, q.Parameters["description"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "description", changes[0]["field"])
+	assert.Equal(t, "old desc", changes[0]["oldValue"])
+	assert.Nil(t, changes[0]["newValue"])
+}
+
+func TestPatchCatalogueItemQuery_DetailsMergeNoDelete(t *testing.T) {
+	details := []models.CatalogueItemDetail{
+		{Property: models.CatalogueCategoryProperty{UID: "prop-A", Name: "Voltage", Type: models.CatalogueCategoryPropertyType{Code: "text"}}, Value: "24"},
+	}
+	fields := &models.PatchCatalogueItemFields{Details: &details}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "MERGE(item)-[r_pp0:HAS_CATALOGUE_PROPERTY]->(pp0)")
+	assert.Contains(t, q.Query, "SET r_pp0.value = $propValue0")
+	assert.NotContains(t, q.Query, "DELETE r_propToDelete")
+	assert.Equal(t, "prop-A", q.Parameters["propUID0"])
+	assert.Equal(t, "24", q.Parameters["propValue0"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "Voltage", changes[0]["field"])
+	assert.Equal(t, "string", changes[0]["type"])
+	assert.Equal(t, "12", changes[0]["oldValue"])
+	assert.Equal(t, "24", changes[0]["newValue"])
+}
+
+func TestPatchCatalogueItemQuery_DetailsEmptyArray_NoOp(t *testing.T) {
+	empty := []models.CatalogueItemDetail{}
+	fields := &models.PatchCatalogueItemFields{Details: &empty}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.NotContains(t, q.Query, "HAS_CATALOGUE_PROPERTY")
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 0)
+}
+
+func TestPatchCatalogueItemQuery_SupplierChange(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{
+		Supplier: &models.Optional[codebookModels.Codebook]{Value: &codebookModels.Codebook{UID: "supp-new", Name: "New Supp"}},
+	}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "OPTIONAL MATCH (item)-[oldSup:HAS_SUPPLIER]->()")
+	assert.Contains(t, q.Query, "DELETE oldSup")
+	assert.Contains(t, q.Query, "MATCH(newSup:Supplier{uid: $supplierUid})")
+	assert.Contains(t, q.Query, "MERGE(item)-[:HAS_SUPPLIER]->(newSup)")
+	assert.Equal(t, "supp-new", q.Parameters["supplierUid"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "supplier", changes[0]["field"])
+	assert.Equal(t, "codebook", changes[0]["type"])
+}
+
+func TestPatchCatalogueItemQuery_SupplierClear(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{
+		Supplier: &models.Optional[codebookModels.Codebook]{Value: nil},
+	}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "DELETE oldSup")
+	assert.NotContains(t, q.Query, "MERGE(item)-[:HAS_SUPPLIER]")
+	assert.Nil(t, q.Parameters["supplierUid"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "supplier", changes[0]["field"])
+	assert.Nil(t, changes[0]["newValue"])
+}
+
+func TestPatchCatalogueItemQuery_CategoryChange(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{
+		Category: &codebookModels.Codebook{UID: "cat-new", Name: "New Cat"},
+	}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "OPTIONAL MATCH (item)-[oldCat:BELONGS_TO_CATEGORY]->()")
+	assert.Contains(t, q.Query, "DELETE oldCat")
+	assert.Contains(t, q.Query, "MERGE(item)-[:BELONGS_TO_CATEGORY]->(newCat)")
+	assert.Equal(t, "cat-new", q.Parameters["categoryUid"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "category", changes[0]["field"])
+	assert.Equal(t, "codebook", changes[0]["type"])
+}
+
+func TestPatchCatalogueItemQuery_NoChanges_EmptyChangesArray(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{Name: ptr("Old Name")}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "SET item.name = $name")
+	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Equal(t, "[]", q.Parameters["changes"])
+}
+
+func TestPatchCatalogueItemQuery_ChangesJsonShape(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{Name: ptr("X"), CatalogueNumber: ptr("CN-002")}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 2)
+	for _, c := range changes {
+		assert.Contains(t, c, "field")
+		assert.Contains(t, c, "type")
+		assert.Contains(t, c, "oldValue")
+		assert.Contains(t, c, "newValue")
+	}
+}
+
+func TestPatchCatalogueItemQuery_AlwaysSetsLastUpdateAndAuditRel(t *testing.T) {
+	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{}, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "SET item.lastUpdateTime = datetime()")
+	assert.Contains(t, q.Query, "CREATE(item)-[:WAS_UPDATED_BY")
+	assert.Contains(t, q.Query, `action: "PATCH"`)
+	assert.Equal(t, "[]", q.Parameters["changes"])
+	assert.Equal(t, "user-1", q.Parameters["userUID"])
+	assert.Equal(t, "item-1", q.Parameters["uid"])
+}

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -2,6 +2,7 @@ package catalogueService
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"panda/apigateway/helpers"
@@ -213,4 +214,81 @@ func TestPatchCatalogueItemQuery_AlwaysSetsLastUpdateAndAuditRel(t *testing.T) {
 	assert.Equal(t, "[]", q.Parameters["changes"])
 	assert.Equal(t, "user-1", q.Parameters["userUID"])
 	assert.Equal(t, "item-1", q.Parameters["uid"])
+}
+
+func TestPatchCatalogueItemQuery_ItemMatchGuardsLastUpdateTime(t *testing.T) {
+	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{}, newOriginalItem(), "user-1")
+
+	assert.Contains(t, q.Query, "WHERE item.lastUpdateTime.epochMillis = $lastUpdateTimeMillis",
+		"MATCH should include lastUpdateTime precondition to defend against TOCTOU races")
+	assert.Equal(t, newOriginalItem().LastUpdateTime.UnixMilli(), q.Parameters["lastUpdateTimeMillis"])
+}
+
+func TestPatchCatalogueItemQuery_SupplierChange_MatchesNewBeforeDelete(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{
+		Supplier: &models.Optional[codebookModels.Codebook]{Value: &codebookModels.Codebook{UID: "supp-new", Name: "New"}},
+	}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	idxMatchNew := strings.Index(q.Query, "MATCH(newSup:Supplier{uid: $supplierUid})")
+	idxDeleteOld := strings.Index(q.Query, "DELETE oldSup")
+	assert.Greater(t, idxMatchNew, -1, "must MATCH new supplier")
+	assert.Greater(t, idxDeleteOld, idxMatchNew,
+		"must MATCH new supplier BEFORE deleting the old relationship")
+}
+
+func TestPatchCatalogueItemQuery_CategoryChange_MatchesNewBeforeDelete(t *testing.T) {
+	fields := &models.PatchCatalogueItemFields{
+		Category: &codebookModels.Codebook{UID: "cat-new", Name: "New Cat"},
+	}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	idxMatchNew := strings.Index(q.Query, "MATCH(newCat:CatalogueCategory{uid: $categoryUid})")
+	idxDeleteOld := strings.Index(q.Query, "DELETE oldCat")
+	assert.Greater(t, idxMatchNew, -1)
+	assert.Greater(t, idxDeleteOld, idxMatchNew,
+		"must MATCH new category BEFORE deleting the old relationship")
+}
+
+func TestPatchCatalogueItemQuery_AuditUsesDBSourcedMetadata(t *testing.T) {
+	// Client sends a spoofed Name and Type.Code; builder should ignore those
+	// in favor of originalItem's canonical metadata.
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{
+			UID:  "prop-B",
+			Name: "SPOOFED_NAME",
+			Type: models.CatalogueCategoryPropertyType{Code: "string"},
+		},
+		Value: "99",
+	}}
+	fields := &models.PatchCatalogueItemFields{Details: &details}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "Weight", changes[0]["field"], "field should come from originalItem, not payload")
+	assert.Equal(t, "number", changes[0]["type"], "type should come from originalItem's Type.Code, not payload")
+}
+
+func TestPatchCatalogueItemQuery_DetailNumberTypeCoercion(t *testing.T) {
+	// originalItem has prop-B (Weight, type "number") stored as string "50".
+	// Payload sends JSON number 50 (float64 in Go) → should NOT register as change.
+	detailsSame := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "prop-B"},
+		Value:    float64(50),
+	}}
+	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{Details: &detailsSame}, newOriginalItem(), "user-1")
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 0, "float 50 normalizes to '50' and matches stored string '50'")
+
+	// Changing the value should register.
+	detailsDiff := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "prop-B"},
+		Value:    float64(75),
+	}}
+	q2 := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{Details: &detailsDiff}, newOriginalItem(), "user-1")
+	changes2 := parseChanges(t, q2)
+	assert.Len(t, changes2, 1)
+	assert.Equal(t, "50", changes2[0]["oldValue"])
+	assert.Equal(t, "75", changes2[0]["newValue"])
 }

--- a/services/catalogue-service/catalogue-db-queries_patch_test.go
+++ b/services/catalogue-service/catalogue-db-queries_patch_test.go
@@ -181,6 +181,29 @@ func TestPatchCatalogueItemQuery_ChangesJsonShape(t *testing.T) {
 	}
 }
 
+func TestPatchCatalogueItemQuery_DetailRangeValue_SerializesAsJson(t *testing.T) {
+	rangeVal := map[string]interface{}{"min": 1.0, "max": 10.0}
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "prop-range", Name: "Frequency", Type: models.CatalogueCategoryPropertyType{Code: "range"}},
+		Value:    rangeVal,
+	}}
+	fields := &models.PatchCatalogueItemFields{Details: &details}
+	q := PatchCatalogueItemQuery("item-1", fields, newOriginalItem(), "user-1")
+
+	raw, ok := q.Parameters["propValue0"].(string)
+	assert.True(t, ok, "range value must be serialized to a JSON string")
+	var parsed map[string]float64
+	assert.NoError(t, json.Unmarshal([]byte(raw), &parsed))
+	assert.Equal(t, 1.0, parsed["min"])
+	assert.Equal(t, 10.0, parsed["max"])
+
+	changes := parseChanges(t, q)
+	assert.Len(t, changes, 1)
+	assert.Equal(t, "Frequency", changes[0]["field"])
+	assert.Equal(t, "string", changes[0]["type"], "range maps to string ChangeType per spec")
+	assert.Equal(t, raw, changes[0]["newValue"], "new value in change entry is the JSON string form")
+}
+
 func TestPatchCatalogueItemQuery_AlwaysSetsLastUpdateAndAuditRel(t *testing.T) {
 	q := PatchCatalogueItemQuery("item-1", &models.PatchCatalogueItemFields{}, newOriginalItem(), "user-1")
 

--- a/services/catalogue-service/catalogue-handlers.go
+++ b/services/catalogue-service/catalogue-handlers.go
@@ -2,6 +2,7 @@ package catalogueService
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -582,9 +583,11 @@ func (h *CatalogueHandlers) PatchCatalogueItem() echo.HandlerFunc {
 		updatedItem, err := h.catalogueService.PatchCatalogueItem(uid, fields, userUID)
 		if err == nil {
 			return c.JSON(http.StatusOK, updatedItem)
-		} else if err == helpers.ERR_CONFLICT {
+		} else if errors.Is(err, helpers.ERR_CONFLICT) {
 			log.Err(helpers.ERR_CONFLICT).Msg("Catalogue item was updated by another user")
 			return echo.ErrConflict
+		} else if errors.Is(err, helpers.ERR_NOT_FOUND) {
+			return echo.ErrNotFound
 		}
 
 		log.Error().Err(err).Msg("Error patching catalogue item")
@@ -660,6 +663,9 @@ func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.Pat
 			if err := json.Unmarshal(r, &cb); err != nil {
 				return nil, fmt.Errorf("invalid supplier: %w", err)
 			}
+			if cb.UID == "" {
+				return nil, fmt.Errorf("supplier.uid is required; to clear the supplier send supplier: null")
+			}
 			fields.Supplier = &models.Optional[codebookModels.Codebook]{Value: &cb}
 		}
 	}
@@ -668,6 +674,9 @@ func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.Pat
 		var cb codebookModels.Codebook
 		if err := json.Unmarshal(r, &cb); err != nil {
 			return nil, fmt.Errorf("invalid category: %w", err)
+		}
+		if cb.UID == "" {
+			return nil, fmt.Errorf("category.uid is required")
 		}
 		fields.Category = &cb
 	}

--- a/services/catalogue-service/catalogue-handlers.go
+++ b/services/catalogue-service/catalogue-handlers.go
@@ -1,6 +1,7 @@
 package catalogueService
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
 	codebookModels "panda/apigateway/services/codebook-service/models"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -588,11 +590,32 @@ func (h *CatalogueHandlers) PatchCatalogueItem() echo.HandlerFunc {
 			return echo.ErrConflict
 		} else if errors.Is(err, helpers.ERR_NOT_FOUND) {
 			return echo.ErrNotFound
+		} else if isPatchValidationError(err) {
+			return helpers.BadRequest(err.Error())
 		}
 
 		log.Error().Err(err).Msg("Error patching catalogue item")
 		return echo.ErrInternalServerError
 	}
+}
+
+// isPatchValidationError identifies service-layer reference validation failures
+// (unknown supplier/category/property UID) so the handler returns 400 instead of 500.
+func isPatchValidationError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "supplier not found") ||
+		strings.Contains(msg, "category not found") ||
+		strings.Contains(msg, "property ") ||
+		strings.Contains(msg, "detail.property.uid")
+}
+
+// rawMessageIsNull reports whether a json.RawMessage contains the literal token
+// "null", tolerating surrounding whitespace (encoding/json preserves it in RawMessage).
+func rawMessageIsNull(r json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(r), []byte("null"))
 }
 
 // parsePatchCatalogueItemPayload maps a json.RawMessage map into the typed
@@ -629,7 +652,7 @@ func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.Pat
 		if !ok {
 			return nil, nil
 		}
-		if string(r) == "null" {
+		if rawMessageIsNull(r) {
 			return &models.Optional[string]{Value: nil}, nil
 		}
 		var v string
@@ -656,7 +679,7 @@ func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.Pat
 	}
 
 	if r, ok := raw["supplier"]; ok {
-		if string(r) == "null" {
+		if rawMessageIsNull(r) {
 			fields.Supplier = &models.Optional[codebookModels.Codebook]{Value: nil}
 		} else {
 			var cb codebookModels.Codebook
@@ -670,7 +693,10 @@ func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.Pat
 		}
 	}
 
-	if r, ok := raw["category"]; ok && string(r) != "null" {
+	if r, ok := raw["category"]; ok {
+		if rawMessageIsNull(r) {
+			return nil, fmt.Errorf("category cannot be null; category is required for catalogue items")
+		}
 		var cb codebookModels.Codebook
 		if err := json.Unmarshal(r, &cb); err != nil {
 			return nil, fmt.Errorf("invalid category: %w", err)

--- a/services/catalogue-service/catalogue-handlers.go
+++ b/services/catalogue-service/catalogue-handlers.go
@@ -10,7 +10,6 @@ import (
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
 	codebookModels "panda/apigateway/services/codebook-service/models"
-	"strings"
 
 	"github.com/rs/zerolog/log"
 
@@ -555,8 +554,9 @@ func (h *CatalogueHandlers) UpdateCatalogueItem() echo.HandlerFunc {
 // @Param uid path string true "Catalogue item UID"
 // @Param body body object true "Partial catalogue item payload"
 // @Success 200 {object} models.CatalogueItem
-// @Failure 400 "Bad Request"
-// @Failure 409 "Conflict"
+// @Failure 400 "Bad Request — malformed body, missing lastUpdateTime, or unknown supplier/category/property UID"
+// @Failure 404 "Not Found — catalogue item does not exist"
+// @Failure 409 "Conflict — lastUpdateTime mismatch or concurrent update detected"
 // @Failure 500 "Internal server error"
 // @Router /v1/catalogue/item/{uid} [patch]
 func (h *CatalogueHandlers) PatchCatalogueItem() echo.HandlerFunc {
@@ -590,26 +590,13 @@ func (h *CatalogueHandlers) PatchCatalogueItem() echo.HandlerFunc {
 			return echo.ErrConflict
 		} else if errors.Is(err, helpers.ERR_NOT_FOUND) {
 			return echo.ErrNotFound
-		} else if isPatchValidationError(err) {
+		} else if errors.Is(err, ErrPatchValidation) {
 			return helpers.BadRequest(err.Error())
 		}
 
 		log.Error().Err(err).Msg("Error patching catalogue item")
 		return echo.ErrInternalServerError
 	}
-}
-
-// isPatchValidationError identifies service-layer reference validation failures
-// (unknown supplier/category/property UID) so the handler returns 400 instead of 500.
-func isPatchValidationError(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "supplier not found") ||
-		strings.Contains(msg, "category not found") ||
-		strings.Contains(msg, "property ") ||
-		strings.Contains(msg, "detail.property.uid")
 }
 
 // rawMessageIsNull reports whether a json.RawMessage contains the literal token

--- a/services/catalogue-service/catalogue-handlers.go
+++ b/services/catalogue-service/catalogue-handlers.go
@@ -2,9 +2,12 @@ package catalogueService
 
 import (
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
+	codebookModels "panda/apigateway/services/codebook-service/models"
 
 	"github.com/rs/zerolog/log"
 
@@ -30,6 +33,7 @@ type ICatalogueHandlers interface {
 	GetCatalogueCategoryPropertiesByUid() echo.HandlerFunc
 	GetCatalogueCategoryPhysicalItemPropertiesByUid() echo.HandlerFunc
 	UpdateCatalogueItem() echo.HandlerFunc
+	PatchCatalogueItem() echo.HandlerFunc
 	DeleteCatalogueItem() echo.HandlerFunc
 	GetCatalogueItemStatistics() echo.HandlerFunc
 	CatalogueItemsOverallStatistics() echo.HandlerFunc
@@ -534,6 +538,149 @@ func (h *CatalogueHandlers) UpdateCatalogueItem() echo.HandlerFunc {
 
 		return echo.ErrInternalServerError
 	}
+}
+
+// PatchCatalogueItem godoc
+// @Summary Partially update catalogue item
+// @Description Applies a partial update to a catalogue item. Only fields present in the JSON body are modified.
+// @Description Required: lastUpdateTime (for conflict detection). Supported keys: name, catalogueNumber, description, manufacturerUrl, manufacturerNumber, supplier, category, details.
+// @Description Scalar fields set to JSON null are cleared. Missing keys are left untouched. Details are merged (no deletion); send value:null to clear a single detail's value.
+// @Tags Catalogue
+// @Accept json
+// @Produce json
+// @Security BearerAuth
+// @Param uid path string true "Catalogue item UID"
+// @Param body body object true "Partial catalogue item payload"
+// @Success 200 {object} models.CatalogueItem
+// @Failure 400 "Bad Request"
+// @Failure 409 "Conflict"
+// @Failure 500 "Internal server error"
+// @Router /v1/catalogue/item/{uid} [patch]
+func (h *CatalogueHandlers) PatchCatalogueItem() echo.HandlerFunc {
+
+	return func(c echo.Context) error {
+
+		uid := c.Param("uid")
+
+		body, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			return helpers.BadRequest("cannot read request body")
+		}
+
+		raw := map[string]json.RawMessage{}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return helpers.BadRequest("invalid JSON body")
+		}
+
+		fields, err := parsePatchCatalogueItemPayload(raw)
+		if err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		userUID := c.Get("userUID").(string)
+
+		updatedItem, err := h.catalogueService.PatchCatalogueItem(uid, fields, userUID)
+		if err == nil {
+			return c.JSON(http.StatusOK, updatedItem)
+		} else if err == helpers.ERR_CONFLICT {
+			log.Err(helpers.ERR_CONFLICT).Msg("Catalogue item was updated by another user")
+			return echo.ErrConflict
+		}
+
+		log.Error().Err(err).Msg("Error patching catalogue item")
+		return echo.ErrInternalServerError
+	}
+}
+
+// parsePatchCatalogueItemPayload maps a json.RawMessage map into the typed
+// PatchCatalogueItemFields struct. Keys absent from the map stay nil; explicit
+// JSON null is captured via Optional[T] with Value=nil.
+func parsePatchCatalogueItemPayload(raw map[string]json.RawMessage) (*models.PatchCatalogueItemFields, error) {
+	fields := &models.PatchCatalogueItemFields{}
+
+	lutRaw, ok := raw["lastUpdateTime"]
+	if !ok {
+		return nil, fmt.Errorf("lastUpdateTime is required")
+	}
+	if err := json.Unmarshal(lutRaw, &fields.LastUpdateTime); err != nil {
+		return nil, fmt.Errorf("invalid lastUpdateTime: %w", err)
+	}
+
+	if r, ok := raw["name"]; ok {
+		var v string
+		if err := json.Unmarshal(r, &v); err != nil {
+			return nil, fmt.Errorf("invalid name: %w", err)
+		}
+		fields.Name = &v
+	}
+	if r, ok := raw["catalogueNumber"]; ok {
+		var v string
+		if err := json.Unmarshal(r, &v); err != nil {
+			return nil, fmt.Errorf("invalid catalogueNumber: %w", err)
+		}
+		fields.CatalogueNumber = &v
+	}
+
+	parseOptString := func(key string) (*models.Optional[string], error) {
+		r, ok := raw[key]
+		if !ok {
+			return nil, nil
+		}
+		if string(r) == "null" {
+			return &models.Optional[string]{Value: nil}, nil
+		}
+		var v string
+		if err := json.Unmarshal(r, &v); err != nil {
+			return nil, fmt.Errorf("invalid %s: %w", key, err)
+		}
+		return &models.Optional[string]{Value: &v}, nil
+	}
+
+	if v, err := parseOptString("description"); err != nil {
+		return nil, err
+	} else {
+		fields.Description = v
+	}
+	if v, err := parseOptString("manufacturerUrl"); err != nil {
+		return nil, err
+	} else {
+		fields.ManufacturerUrl = v
+	}
+	if v, err := parseOptString("manufacturerNumber"); err != nil {
+		return nil, err
+	} else {
+		fields.ManufacturerNumber = v
+	}
+
+	if r, ok := raw["supplier"]; ok {
+		if string(r) == "null" {
+			fields.Supplier = &models.Optional[codebookModels.Codebook]{Value: nil}
+		} else {
+			var cb codebookModels.Codebook
+			if err := json.Unmarshal(r, &cb); err != nil {
+				return nil, fmt.Errorf("invalid supplier: %w", err)
+			}
+			fields.Supplier = &models.Optional[codebookModels.Codebook]{Value: &cb}
+		}
+	}
+
+	if r, ok := raw["category"]; ok && string(r) != "null" {
+		var cb codebookModels.Codebook
+		if err := json.Unmarshal(r, &cb); err != nil {
+			return nil, fmt.Errorf("invalid category: %w", err)
+		}
+		fields.Category = &cb
+	}
+
+	if r, ok := raw["details"]; ok {
+		var details []models.CatalogueItemDetail
+		if err := json.Unmarshal(r, &details); err != nil {
+			return nil, fmt.Errorf("invalid details: %w", err)
+		}
+		fields.Details = &details
+	}
+
+	return fields, nil
 }
 
 // DeleteCatalogueItem godoc

--- a/services/catalogue-service/catalogue-routes.go
+++ b/services/catalogue-service/catalogue-routes.go
@@ -38,6 +38,8 @@ func MapCatalogueRoutes(e *echo.Echo, h ICatalogueHandlers, jwtMiddleware echo.M
 	e.POST("/v1/catalogue/item", m.Authorization(h.CreateNewCatalogueItem(), shared.ROLE_CATALOGUE_EDIT), jwtMiddleware)
 	//update catalogue item
 	e.PUT("/v1/catalogue/item/:uid", m.Authorization(h.UpdateCatalogueItem(), shared.ROLE_CATALOGUE_EDIT), jwtMiddleware)
+	//partial update catalogue item (JSON merge patch semantics)
+	e.PATCH("/v1/catalogue/item/:uid", m.Authorization(h.PatchCatalogueItem(), shared.ROLE_CATALOGUE_EDIT), jwtMiddleware)
 	//delete catalogue item
 	e.DELETE("/v1/catalogue/item/:uid", m.Authorization(h.DeleteCatalogueItem(), shared.ROLE_CATALOGUE_EDIT), jwtMiddleware)
 	//get catalogue item statistics

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -3,6 +3,7 @@ package catalogueService
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"panda/apigateway/config"
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
@@ -439,14 +440,78 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 		return result, helpers.ERR_CONFLICT
 	}
 
-	query := PatchCatalogueItemQuery(uid, fields, &originalItem, userUID)
-	_, err = helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
-	if err != nil {
+	if err := svc.validatePatchReferences(fields, &originalItem); err != nil {
 		return result, err
+	}
+
+	query := PatchCatalogueItemQuery(uid, fields, &originalItem, userUID)
+	returnedUID, err := helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	if err != nil {
+		// Empty result = MATCH on uid+lastUpdateTime yielded no rows, i.e. a concurrent
+		// write raced us between the initial read and the PATCH execution.
+		if strings.Contains(err.Error(), "no more records") {
+			return result, helpers.ERR_CONFLICT
+		}
+		return result, err
+	}
+	if returnedUID == "" {
+		return result, helpers.ERR_CONFLICT
 	}
 
 	result, err = svc.GetCatalogueItemWithDetailsByUid(uid)
 	return result, err
+}
+
+// validatePatchReferences rejects references to non-existent supplier/category/property
+// nodes before the main PATCH query runs, so an invalid UID produces a clear 400 instead
+// of silently stripping relationships.
+func (svc *CatalogueService) validatePatchReferences(fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem) error {
+	if fields.Supplier != nil && fields.Supplier.Value != nil && fields.Supplier.Value.UID != "" {
+		if exists, err := svc.nodeExists("Supplier", fields.Supplier.Value.UID); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("supplier not found: %s", fields.Supplier.Value.UID)
+		}
+	}
+
+	if fields.Category != nil && fields.Category.UID != "" {
+		if exists, err := svc.nodeExists("CatalogueCategory", fields.Category.UID); err != nil {
+			return err
+		} else if !exists {
+			return fmt.Errorf("category not found: %s", fields.Category.UID)
+		}
+	}
+
+	if fields.Details != nil {
+		knownProps := map[string]bool{}
+		for _, d := range originalItem.Details {
+			knownProps[d.Property.UID] = true
+		}
+		for _, d := range *fields.Details {
+			if d.Property.UID == "" {
+				return fmt.Errorf("detail.property.uid is required")
+			}
+			if !knownProps[d.Property.UID] {
+				return fmt.Errorf("property %s is not part of the item's category; change the category first or send a valid property UID", d.Property.UID)
+			}
+		}
+	}
+
+	return nil
+}
+
+func (svc *CatalogueService) nodeExists(label, uid string) (bool, error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	q := helpers.DatabaseQuery{
+		Query:       fmt.Sprintf("MATCH(n:%s{uid: $uid}) RETURN count(n) as c", label),
+		ReturnAlias: "c",
+		Parameters:  map[string]interface{}{"uid": uid},
+	}
+	c, err := helpers.GetNeo4jSingleRecordSingleValue[int64](session, q)
+	if err != nil {
+		return false, err
+	}
+	return c > 0, nil
 }
 
 func (svc *CatalogueService) DeleteCatalogueItem(uid string, userUID string) (err error) {

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -40,6 +40,7 @@ type ICatalogueService interface {
 	GetCatalogueCategoryPropertiesByUid(uid string, itemUID *string) (properties []models.CatalogueItemDetail, err error)
 	GetCatalogueCategoryPhysicalItemPropertiesByUid(uid string) (properties []models.CatalogueItemDetail, err error)
 	UpdateCatalogueItem(catalogueItem *models.CatalogueItem, userUID string) (result models.CatalogueItem, err error)
+	PatchCatalogueItem(uid string, fields *models.PatchCatalogueItemFields, userUID string) (result models.CatalogueItem, err error)
 	DeleteCatalogueItem(uid string, userUID string) (err error)
 	GetCatalogueItemStatistics(uid string) (result []models.CatalogueStatistics, err error)
 	CatalogueItemsOverallStatistics() (result []models.CatalogueStatistics, err error)
@@ -418,6 +419,29 @@ func (svc *CatalogueService) UpdateCatalogueItem(catalogueItem *models.Catalogue
 		}
 	}
 
+	return result, err
+}
+
+func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.PatchCatalogueItemFields, userUID string) (result models.CatalogueItem, err error) {
+
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+
+	originalItem, err := svc.GetCatalogueItemWithDetailsByUid(uid)
+	if err != nil {
+		return result, err
+	}
+
+	if !fields.LastUpdateTime.Equal(originalItem.LastUpdateTime) {
+		return result, helpers.ERR_CONFLICT
+	}
+
+	query := PatchCatalogueItemQuery(uid, fields, &originalItem, userUID)
+	_, err = helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	if err != nil {
+		return result, err
+	}
+
+	result, err = svc.GetCatalogueItemWithDetailsByUid(uid)
 	return result, err
 }
 

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -516,10 +516,15 @@ func (svc *CatalogueService) validatePatchReferences(fields *models.PatchCatalog
 		for _, d := range originalItem.Details {
 			knownProps[d.Property.UID] = true
 		}
+		seen := map[string]bool{}
 		for _, d := range *fields.Details {
 			if d.Property.UID == "" {
 				return fmt.Errorf("%w: detail.property.uid is required", ErrPatchValidation)
 			}
+			if seen[d.Property.UID] {
+				return fmt.Errorf("%w: duplicate property UID in details: %s", ErrPatchValidation, d.Property.UID)
+			}
+			seen[d.Property.UID] = true
 			if !knownProps[d.Property.UID] {
 				return fmt.Errorf("%w: property %s is not part of the item's category; change the category first or send a valid property UID", ErrPatchValidation, d.Property.UID)
 			}

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -443,7 +443,7 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 		return result, helpers.ERR_CONFLICT
 	}
 
-	if isCombinedCategoryAndDetailsPatch(fields, &originalItem) {
+	if isCombinedCategoryAndDetailsPatch(fields, originalItem.Category.UID) {
 		newCatProps, propErr := svc.GetCatalogueCategoryPropertiesByUid(fields.Category.UID, nil)
 		if propErr != nil {
 			return result, propErr
@@ -481,14 +481,14 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 // supplies details. In that case the service augments originalItem.Details with the new
 // category's property set so detail UIDs from the target category pass validation
 // and the Cypher builder can source DB-backed Name/Type.Code for audit entries.
-func isCombinedCategoryAndDetailsPatch(fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem) bool {
+func isCombinedCategoryAndDetailsPatch(fields *models.PatchCatalogueItemFields, oldCategoryUID string) bool {
 	if fields.Details == nil || fields.Category == nil {
 		return false
 	}
 	if fields.Category.UID == "" {
 		return false
 	}
-	return fields.Category.UID != originalItem.Category.UID
+	return fields.Category.UID != oldCategoryUID
 }
 
 // validatePatchReferences rejects references to non-existent supplier/category/property

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -7,6 +7,7 @@ import (
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
 	codebookModels "panda/apigateway/services/codebook-service/models"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -428,6 +429,9 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 
 	originalItem, err := svc.GetCatalogueItemWithDetailsByUid(uid)
 	if err != nil {
+		if strings.Contains(err.Error(), "no more records") {
+			return result, helpers.ERR_NOT_FOUND
+		}
 		return result, err
 	}
 

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -8,7 +8,6 @@ import (
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/catalogue-service/models"
 	codebookModels "panda/apigateway/services/codebook-service/models"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
@@ -424,13 +423,17 @@ func (svc *CatalogueService) UpdateCatalogueItem(catalogueItem *models.Catalogue
 	return result, err
 }
 
+// ErrPatchValidation marks errors from PATCH reference validation (unknown supplier/
+// category/property UID, missing property UID). The handler uses errors.Is to surface 400.
+var ErrPatchValidation = errors.New("patch validation failed")
+
 func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.PatchCatalogueItemFields, userUID string) (result models.CatalogueItem, err error) {
 
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 
 	originalItem, err := svc.GetCatalogueItemWithDetailsByUid(uid)
 	if err != nil {
-		if strings.Contains(err.Error(), "no more records") {
+		if errors.Is(err, helpers.ERR_NO_ROWS) {
 			return result, helpers.ERR_NOT_FOUND
 		}
 		return result, err
@@ -438,6 +441,21 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 
 	if !fields.LastUpdateTime.Equal(originalItem.LastUpdateTime) {
 		return result, helpers.ERR_CONFLICT
+	}
+
+	// If the PATCH also changes category, augment originalItem.Details with the new
+	// category's property set so detail UIDs from the target category pass validation
+	// and the Cypher builder can source DB-backed Name/Type.Code for the audit entries.
+	if fields.Category != nil && fields.Category.UID != "" && fields.Category.UID != originalItem.Category.UID && fields.Details != nil {
+		newCatProps, propErr := svc.GetCatalogueCategoryPropertiesByUid(fields.Category.UID, nil)
+		if propErr != nil {
+			return result, propErr
+		}
+		for _, p := range newCatProps {
+			if findDetailByPropUID(originalItem.Details, p.Property.UID) == nil {
+				originalItem.Details = append(originalItem.Details, models.CatalogueItemDetail{Property: p.Property, PropertyGroup: p.PropertyGroup, Value: nil})
+			}
+		}
 	}
 
 	if err := svc.validatePatchReferences(fields, &originalItem); err != nil {
@@ -449,7 +467,7 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 	if err != nil {
 		// Empty result = MATCH on uid+lastUpdateTime yielded no rows, i.e. a concurrent
 		// write raced us between the initial read and the PATCH execution.
-		if strings.Contains(err.Error(), "no more records") {
+		if errors.Is(err, helpers.ERR_NO_ROWS) {
 			return result, helpers.ERR_CONFLICT
 		}
 		return result, err
@@ -464,13 +482,13 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 
 // validatePatchReferences rejects references to non-existent supplier/category/property
 // nodes before the main PATCH query runs, so an invalid UID produces a clear 400 instead
-// of silently stripping relationships.
+// of silently stripping relationships. Returned errors wrap ErrPatchValidation.
 func (svc *CatalogueService) validatePatchReferences(fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem) error {
 	if fields.Supplier != nil && fields.Supplier.Value != nil && fields.Supplier.Value.UID != "" {
 		if exists, err := svc.nodeExists("Supplier", fields.Supplier.Value.UID); err != nil {
 			return err
 		} else if !exists {
-			return fmt.Errorf("supplier not found: %s", fields.Supplier.Value.UID)
+			return fmt.Errorf("%w: supplier not found: %s", ErrPatchValidation, fields.Supplier.Value.UID)
 		}
 	}
 
@@ -478,7 +496,7 @@ func (svc *CatalogueService) validatePatchReferences(fields *models.PatchCatalog
 		if exists, err := svc.nodeExists("CatalogueCategory", fields.Category.UID); err != nil {
 			return err
 		} else if !exists {
-			return fmt.Errorf("category not found: %s", fields.Category.UID)
+			return fmt.Errorf("%w: category not found: %s", ErrPatchValidation, fields.Category.UID)
 		}
 	}
 
@@ -489,10 +507,10 @@ func (svc *CatalogueService) validatePatchReferences(fields *models.PatchCatalog
 		}
 		for _, d := range *fields.Details {
 			if d.Property.UID == "" {
-				return fmt.Errorf("detail.property.uid is required")
+				return fmt.Errorf("%w: detail.property.uid is required", ErrPatchValidation)
 			}
 			if !knownProps[d.Property.UID] {
-				return fmt.Errorf("property %s is not part of the item's category; change the category first or send a valid property UID", d.Property.UID)
+				return fmt.Errorf("%w: property %s is not part of the item's category; change the category first or send a valid property UID", ErrPatchValidation, d.Property.UID)
 			}
 		}
 	}

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -19,6 +19,10 @@ type CatalogueService struct {
 	jwtSecret   string
 }
 
+// ErrPatchValidation marks errors from PATCH reference validation (unknown supplier/
+// category/property UID, missing property UID). The handler uses errors.Is to surface 400.
+var ErrPatchValidation = errors.New("patch validation failed")
+
 type ICatalogueService interface {
 	GetCatalogueCategoriesByParentPath(parentPath string) (categories []models.CatalogueCategory, err error)
 	GetCatalogueItems(search string, categoryUid string, pageSize int, page int, filering *[]helpers.ColumnFilter, sorting *[]helpers.Sorting) (result helpers.PaginationResult[models.CatalogueItemSimple], err error)
@@ -423,10 +427,6 @@ func (svc *CatalogueService) UpdateCatalogueItem(catalogueItem *models.Catalogue
 	return result, err
 }
 
-// ErrPatchValidation marks errors from PATCH reference validation (unknown supplier/
-// category/property UID, missing property UID). The handler uses errors.Is to surface 400.
-var ErrPatchValidation = errors.New("patch validation failed")
-
 func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.PatchCatalogueItemFields, userUID string) (result models.CatalogueItem, err error) {
 
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
@@ -443,10 +443,7 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 		return result, helpers.ERR_CONFLICT
 	}
 
-	// If the PATCH also changes category, augment originalItem.Details with the new
-	// category's property set so detail UIDs from the target category pass validation
-	// and the Cypher builder can source DB-backed Name/Type.Code for the audit entries.
-	if fields.Category != nil && fields.Category.UID != "" && fields.Category.UID != originalItem.Category.UID && fields.Details != nil {
+	if isCombinedCategoryAndDetailsPatch(fields, &originalItem) {
 		newCatProps, propErr := svc.GetCatalogueCategoryPropertiesByUid(fields.Category.UID, nil)
 		if propErr != nil {
 			return result, propErr
@@ -478,6 +475,20 @@ func (svc *CatalogueService) PatchCatalogueItem(uid string, fields *models.Patch
 
 	result, err = svc.GetCatalogueItemWithDetailsByUid(uid)
 	return result, err
+}
+
+// isCombinedCategoryAndDetailsPatch reports whether a PATCH swaps category AND also
+// supplies details. In that case the service augments originalItem.Details with the new
+// category's property set so detail UIDs from the target category pass validation
+// and the Cypher builder can source DB-backed Name/Type.Code for audit entries.
+func isCombinedCategoryAndDetailsPatch(fields *models.PatchCatalogueItemFields, originalItem *models.CatalogueItem) bool {
+	if fields.Details == nil || fields.Category == nil {
+		return false
+	}
+	if fields.Category.UID == "" {
+		return false
+	}
+	return fields.Category.UID != originalItem.Category.UID
 }
 
 // validatePatchReferences rejects references to non-existent supplier/category/property

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -461,6 +461,86 @@ func TestParsePatchCatalogueItemPayload_NullCategory_Rejected(t *testing.T) {
 	assert.Contains(t, err.Error(), "category cannot be null")
 }
 
+func TestPatchCatalogueItemQuery_CypherLockRejectsStaleTimestamp(t *testing.T) {
+	// This test bypasses the service-layer Go check by calling the Cypher directly,
+	// proving the WHERE item.lastUpdateTime.epochMillis = ... guard actually works.
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	// Advance the stored timestamp so it no longer matches `original`.
+	_, err := testsetup.TestSession.Run(
+		`MATCH(i:CatalogueItem{uid: $uid}) SET i.lastUpdateTime = datetime() + duration({seconds: 1}) RETURN i`,
+		map[string]interface{}{"uid": f.itemUID},
+	)
+	assert.NoError(t, err)
+
+	// Build and execute the PATCH query with the original (now stale) timestamp.
+	newName := "ForcedViaCypher"
+	query := PatchCatalogueItemQuery(f.itemUID, &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: original.LastUpdateTime,
+	}, &original, f.userUID)
+
+	session, _ := helpers.NewNeo4jSession(testsetup.TestDriver)
+	_, err = helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	assert.ErrorIs(t, err, helpers.ERR_NO_ROWS, "Cypher MATCH should return zero rows for stale lastUpdateTime")
+
+	// verify the item name was NOT written
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.Equal(t, "Original Item", reloaded.Name, "stale PATCH must not reach SET item.name")
+}
+
+func TestPatchCatalogueItem_CombinedCategoryAndDetails(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	// Seed a property on the second category so we can include it in the combined PATCH.
+	newPropUID := "pt-newcat-prop-" + uuid.NewString()
+	newGrpUID := "pt-newcat-grp-" + uuid.NewString()
+	_, err := testsetup.TestSession.Run(`
+		MATCH (cat2:CatalogueCategory{uid: $cat2})
+		MATCH (typeStr:CatalogueCategoryPropertyType{code: 'text'})
+		CREATE (p:CatalogueCategoryProperty {uid: $propUID, name: 'Wavelength'})
+		CREATE (p)-[:IS_PROPERTY_TYPE]->(typeStr)
+		CREATE (grp:CatalogueCategoryPropertyGroup {uid: $grpUID, name: 'NewGrp'})
+		CREATE (cat2)-[:HAS_GROUP]->(grp)
+		CREATE (grp)-[:CONTAINS_PROPERTY]->(p)
+	`, map[string]interface{}{"cat2": f.category2, "propUID": newPropUID, "grpUID": newGrpUID})
+	assert.NoError(t, err)
+	defer testsetup.TestSession.Run(`MATCH (n) WHERE n.uid IN [$p, $g] DETACH DELETE n`,
+		map[string]interface{}{"p": newPropUID, "g": newGrpUID})
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	// PATCH swaps category AND sets a detail belonging to the new category.
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: newPropUID},
+		Value:    "650nm",
+	}}
+	updated, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Category:       &codebookModels.Codebook{UID: f.category2, Name: "PatchTestCat2"},
+		Details:        &details,
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.NoError(t, err, "combined category + new-category details should be accepted")
+	assert.Equal(t, f.category2, updated.Category.UID)
+
+	// verify the new detail value is persisted
+	found := false
+	for _, d := range updated.Details {
+		if d.Property.UID == newPropUID {
+			assert.Equal(t, "650nm", d.Value)
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "new-category property should appear in the updated item")
+}
+
 func TestParsePatchCatalogueItemPayload_NullDescription_WhitespaceTolerant(t *testing.T) {
 	raw := map[string]json.RawMessage{
 		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -3,6 +3,7 @@ package catalogueService
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"panda/apigateway/config"
 	"panda/apigateway/helpers"
@@ -338,4 +339,35 @@ func TestParsePatchCatalogueItemPayload_AbsentDescription(t *testing.T) {
 	fields, err := parsePatchCatalogueItemPayload(raw)
 	assert.NoError(t, err)
 	assert.Nil(t, fields.Description, "absent key maps to nil Optional pointer")
+}
+
+func TestParsePatchCatalogueItemPayload_CategoryEmptyUID_Rejected(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+		"category":       json.RawMessage(`{}`),
+	}
+	_, err := parsePatchCatalogueItemPayload(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "category.uid")
+}
+
+func TestParsePatchCatalogueItemPayload_SupplierEmptyUID_Rejected(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+		"supplier":       json.RawMessage(`{"name":"X"}`),
+	}
+	_, err := parsePatchCatalogueItemPayload(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "supplier.uid")
+}
+
+func TestPatchCatalogueItem_UnknownUid_ReturnsNotFound(t *testing.T) {
+	svc := newPatchSvc()
+
+	newName := "X"
+	_, err := svc.PatchCatalogueItem("does-not-exist-"+uuid.NewString(), &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: time.Now(),
+	}, "anything")
+	assert.ErrorIs(t, err, helpers.ERR_NOT_FOUND)
 }

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -371,3 +371,103 @@ func TestPatchCatalogueItem_UnknownUid_ReturnsNotFound(t *testing.T) {
 	}, "anything")
 	assert.ErrorIs(t, err, helpers.ERR_NOT_FOUND)
 }
+
+func TestPatchCatalogueItem_UnknownSupplier_ReturnsValidationError(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	_, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Supplier:       &models.Optional[codebookModels.Codebook]{Value: &codebookModels.Codebook{UID: "nonexistent-" + uuid.NewString()}},
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "supplier not found")
+
+	// verify old supplier relationship still exists
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.NotNil(t, reloaded.Supplier, "original HAS_SUPPLIER must not be deleted when new supplier is invalid")
+	assert.Equal(t, f.supplierUID, reloaded.Supplier.UID)
+}
+
+func TestPatchCatalogueItem_UnknownCategory_ReturnsValidationError(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	_, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Category:       &codebookModels.Codebook{UID: "nonexistent-" + uuid.NewString()},
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "category not found")
+
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.Equal(t, f.categoryUID, reloaded.Category.UID, "original category must not be deleted when new category is invalid")
+}
+
+func TestPatchCatalogueItem_UnknownPropertyUID_ReturnsValidationError(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "not-in-category-" + uuid.NewString()},
+		Value:    "X",
+	}}
+	_, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Details:        &details,
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "property")
+}
+
+func TestPatchCatalogueItem_TOCTOU_CaughtByCypherLock(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	// Simulate a concurrent writer advancing lastUpdateTime between our read and write.
+	_, err := testsetup.TestSession.Run(
+		`MATCH(i:CatalogueItem{uid: $uid}) SET i.lastUpdateTime = datetime() RETURN i`,
+		map[string]interface{}{"uid": f.itemUID},
+	)
+	assert.NoError(t, err)
+
+	// Now attempt PATCH with the original (stale) timestamp. The Go-level check would
+	// normally catch this, but we call with the original ts to force the Cypher-level
+	// check to be the one that rejects.
+	newName := "Raced"
+	_, err = svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.ErrorIs(t, err, helpers.ERR_CONFLICT)
+}
+
+func TestParsePatchCatalogueItemPayload_NullCategory_Rejected(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+		"category":       json.RawMessage(`null`),
+	}
+	_, err := parsePatchCatalogueItemPayload(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "category cannot be null")
+}
+
+func TestParsePatchCatalogueItemPayload_NullDescription_WhitespaceTolerant(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+		"description":    json.RawMessage("  null\n"),
+	}
+	fields, err := parsePatchCatalogueItemPayload(raw)
+	assert.NoError(t, err)
+	assert.NotNil(t, fields.Description)
+	assert.Nil(t, fields.Description.Value)
+}

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -555,6 +555,40 @@ func TestPatchCatalogueItemQuery_Phase1MatchFailure_NoPartialWrite(t *testing.T)
 	assert.Equal(t, f.categoryUID, reloaded.Category.UID, "category must stay intact")
 }
 
+func TestPatchCatalogueItemQuery_Phase1MissingDetailProperty_NoPartialWrite(t *testing.T) {
+	// Closer to the category test above, but exercising the detail-property MATCH in phase 1.
+	// Bypass service pre-validation by forging a detail with a property UID absent from DB.
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	originalTS := original.LastUpdateTime
+
+	bogusDetails := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: "nonexistent-prop-" + uuid.NewString()},
+		Value:    "should-never-write",
+	}}
+	query := PatchCatalogueItemQuery(f.itemUID, &models.PatchCatalogueItemFields{
+		Details:        &bogusDetails,
+		LastUpdateTime: originalTS,
+	}, &original, f.userUID)
+
+	session, _ := helpers.NewNeo4jSession(testsetup.TestDriver)
+	_, err := helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	assert.ErrorIs(t, err, helpers.ERR_NO_ROWS, "missing detail-property ref should yield zero rows")
+
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.True(t, reloaded.LastUpdateTime.Equal(originalTS),
+		"phase-1 MATCH failure on detail property must not advance lastUpdateTime")
+
+	// also verify no stray HAS_CATALOGUE_PROPERTY relationship was created to the missing UID
+	for _, d := range reloaded.Details {
+		assert.NotEqual(t, bogusDetails[0].Property.UID, d.Property.UID,
+			"bogus property UID must never appear on the reloaded item")
+	}
+}
+
 func TestPatchCatalogueItem_CombinedCategoryAndDetails(t *testing.T) {
 	f := seedPatchFixture(t)
 	defer cleanupPatchFixture(f)

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -121,7 +121,7 @@ func readLatestChanges(t *testing.T, itemUID string) (string, string) {
 	t.Helper()
 	res, err := testsetup.TestSession.Run(`
 		MATCH (i:CatalogueItem{uid: $uid})-[r:WAS_UPDATED_BY]->()
-		WHERE r.action = 'PATCH'
+		WHERE r.action = 'UPDATE'
 		RETURN r.changes as changes, r.action as action
 		ORDER BY r.at DESC LIMIT 1
 	`, map[string]interface{}{"uid": itemUID})
@@ -162,7 +162,7 @@ func TestPatchCatalogueItem_UpdatesNameOnly(t *testing.T) {
 	assert.Equal(t, f.supplierUID, updated.Supplier.UID, "supplier must not change")
 
 	changes, action := readLatestChanges(t, f.itemUID)
-	assert.Equal(t, "PATCH", action)
+	assert.Equal(t, "UPDATE", action)
 	var parsed []map[string]interface{}
 	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
 	assert.Len(t, parsed, 1)
@@ -263,7 +263,7 @@ func TestPatchCatalogueItem_IdempotentCall_EmptyChanges(t *testing.T) {
 	assert.NoError(t, err)
 
 	changes, action := readLatestChanges(t, f.itemUID)
-	assert.Equal(t, "PATCH", action)
+	assert.Equal(t, "UPDATE", action)
 	assert.Equal(t, "[]", changes, "idempotent PATCH should record empty changes array")
 }
 

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -493,6 +493,34 @@ func TestPatchCatalogueItemQuery_CypherLockRejectsStaleTimestamp(t *testing.T) {
 	assert.Equal(t, "Original Item", reloaded.Name, "stale PATCH must not reach SET item.name")
 }
 
+func TestPatchCatalogueItemQuery_Phase1MatchFailure_NoPartialWrite(t *testing.T) {
+	// Guards against the Cypher pitfall where writes executed before a later failing
+	// MATCH are still applied inside the transaction. The builder places ALL MATCHes
+	// (user, item, supplier, category, each detail property) before ANY write, so a
+	// missing reference yields zero rows and no writes — including lastUpdateTime.
+	// This test bypasses the service-layer pre-validation by calling the query directly.
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	originalTS := original.LastUpdateTime
+
+	query := PatchCatalogueItemQuery(f.itemUID, &models.PatchCatalogueItemFields{
+		Category:       &codebookModels.Codebook{UID: "nonexistent-cat-" + uuid.NewString()},
+		LastUpdateTime: originalTS,
+	}, &original, f.userUID)
+
+	session, _ := helpers.NewNeo4jSession(testsetup.TestDriver)
+	_, err := helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	assert.ErrorIs(t, err, helpers.ERR_NO_ROWS, "missing category ref should yield zero rows")
+
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.True(t, reloaded.LastUpdateTime.Equal(originalTS),
+		"phase-1 MATCH failure must not advance lastUpdateTime")
+	assert.Equal(t, f.categoryUID, reloaded.Category.UID, "category must stay intact")
+}
+
 func TestPatchCatalogueItem_CombinedCategoryAndDetails(t *testing.T) {
 	f := seedPatchFixture(t)
 	defer cleanupPatchFixture(f)

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -408,6 +408,32 @@ func TestPatchCatalogueItem_UnknownCategory_ReturnsValidationError(t *testing.T)
 	assert.Equal(t, f.categoryUID, reloaded.Category.UID, "original category must not be deleted when new category is invalid")
 }
 
+func TestPatchCatalogueItem_DuplicatePropertyUIDs_ReturnsValidationError(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	details := []models.CatalogueItemDetail{
+		{Property: models.CatalogueCategoryProperty{UID: f.propAUID}, Value: "first"},
+		{Property: models.CatalogueCategoryProperty{UID: f.propAUID}, Value: "second"},
+	}
+	_, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Details:        &details,
+		LastUpdateTime: original.LastUpdateTime,
+	}, f.userUID)
+	assert.ErrorIs(t, err, ErrPatchValidation)
+	assert.Contains(t, err.Error(), "duplicate property UID")
+
+	// Verify nothing was written — original value "12" untouched.
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	for _, d := range reloaded.Details {
+		if d.Property.UID == f.propAUID {
+			assert.Equal(t, "12", d.Value, "duplicate-UID payload must not reach any write")
+		}
+	}
+}
+
 func TestPatchCatalogueItem_UnknownPropertyUID_ReturnsValidationError(t *testing.T) {
 	f := seedPatchFixture(t)
 	defer cleanupPatchFixture(f)

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -463,7 +463,7 @@ func TestParsePatchCatalogueItemPayload_NullCategory_Rejected(t *testing.T) {
 
 func TestPatchCatalogueItemQuery_CypherLockRejectsStaleTimestamp(t *testing.T) {
 	// This test bypasses the service-layer Go check by calling the Cypher directly,
-	// proving the WHERE item.lastUpdateTime.epochMillis = ... guard actually works.
+	// proving the WHERE item.lastUpdateTime.{epochSeconds,nanosecond} = ... guard works.
 	f := seedPatchFixture(t)
 	defer cleanupPatchFixture(f)
 	svc := newPatchSvc()
@@ -491,6 +491,40 @@ func TestPatchCatalogueItemQuery_CypherLockRejectsStaleTimestamp(t *testing.T) {
 	// verify the item name was NOT written
 	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
 	assert.Equal(t, "Original Item", reloaded.Name, "stale PATCH must not reach SET item.name")
+}
+
+func TestPatchCatalogueItemQuery_CypherLockRejectsSubMillisecondRace(t *testing.T) {
+	// Neo4j datetime() has nanosecond precision; a guard that only compared
+	// epochMillis would let a concurrent write in the same millisecond pass.
+	// Here we advance the stored timestamp by exactly 1 nanosecond and confirm
+	// the query is still rejected.
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	_, err := testsetup.TestSession.Run(
+		`MATCH(i:CatalogueItem{uid: $uid})
+		 SET i.lastUpdateTime = i.lastUpdateTime + duration({nanoseconds: 1})
+		 RETURN i`,
+		map[string]interface{}{"uid": f.itemUID},
+	)
+	assert.NoError(t, err)
+
+	newName := "SubMsRace"
+	query := PatchCatalogueItemQuery(f.itemUID, &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: original.LastUpdateTime,
+	}, &original, f.userUID)
+
+	session, _ := helpers.NewNeo4jSession(testsetup.TestDriver)
+	_, err = helpers.WriteNeo4jAndReturnSingleValue[string](session, query)
+	assert.ErrorIs(t, err, helpers.ERR_NO_ROWS,
+		"sub-ms timestamp drift must still be detected by the nanosecond-precision guard")
+
+	reloaded, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.Equal(t, "Original Item", reloaded.Name)
 }
 
 func TestPatchCatalogueItemQuery_Phase1MatchFailure_NoPartialWrite(t *testing.T) {

--- a/services/catalogue-service/catalogue-service_patch_test.go
+++ b/services/catalogue-service/catalogue-service_patch_test.go
@@ -1,0 +1,341 @@
+package catalogueService
+
+import (
+	"encoding/json"
+	"testing"
+
+	"panda/apigateway/config"
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/catalogue-service/models"
+	codebookModels "panda/apigateway/services/codebook-service/models"
+	"panda/apigateway/services/testsetup"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+type patchFixture struct {
+	itemUID     string
+	categoryUID string
+	category2   string
+	supplierUID string
+	supplier2   string
+	userUID     string
+	propAUID    string
+	propBUID    string
+	propCUID    string
+	grpUID      string
+}
+
+func seedPatchFixture(t *testing.T) patchFixture {
+	t.Helper()
+
+	f := patchFixture{
+		itemUID:     "pt-item-" + uuid.NewString(),
+		categoryUID: "pt-cat-" + uuid.NewString(),
+		category2:   "pt-cat2-" + uuid.NewString(),
+		supplierUID: "pt-supp-" + uuid.NewString(),
+		supplier2:   "pt-supp2-" + uuid.NewString(),
+		userUID:     "pt-user-" + uuid.NewString(),
+		propAUID:    "pt-propA-" + uuid.NewString(),
+		propBUID:    "pt-propB-" + uuid.NewString(),
+		propCUID:    "pt-propC-" + uuid.NewString(),
+		grpUID:      "pt-grp-" + uuid.NewString(),
+	}
+
+	_, err := testsetup.TestSession.Run(`
+		MERGE (typeStr:CatalogueCategoryPropertyType {code: 'text'}) ON CREATE SET typeStr.uid = randomUUID(), typeStr.name = 'Text'
+		MERGE (typeNum:CatalogueCategoryPropertyType {code: 'number'}) ON CREATE SET typeNum.uid = randomUUID(), typeNum.name = 'Number'
+		CREATE (cat:CatalogueCategory {uid: $categoryUID, name: 'PatchTestCat', code: 'PTC'})
+		CREATE (cat2:CatalogueCategory {uid: $category2, name: 'PatchTestCat2', code: 'PTC2'})
+		CREATE (supp:Supplier {uid: $supplierUID, name: 'PatchSupplier'})
+		CREATE (supp2:Supplier {uid: $supplier2, name: 'PatchSupplier2'})
+		CREATE (u:User {uid: $userUID, lastName: 'Tester', firstName: 'Patch'})
+		CREATE (propA:CatalogueCategoryProperty {uid: $propAUID, name: 'Voltage'})
+		CREATE (propB:CatalogueCategoryProperty {uid: $propBUID, name: 'Weight'})
+		CREATE (propC:CatalogueCategoryProperty {uid: $propCUID, name: 'Note'})
+		CREATE (propA)-[:IS_PROPERTY_TYPE]->(typeStr)
+		CREATE (propB)-[:IS_PROPERTY_TYPE]->(typeNum)
+		CREATE (propC)-[:IS_PROPERTY_TYPE]->(typeStr)
+		CREATE (grp:CatalogueCategoryPropertyGroup {uid: $grpUID, name: 'General'})
+		CREATE (cat)-[:HAS_GROUP]->(grp)
+		CREATE (grp)-[:CONTAINS_PROPERTY]->(propA)
+		CREATE (grp)-[:CONTAINS_PROPERTY]->(propB)
+		CREATE (grp)-[:CONTAINS_PROPERTY]->(propC)
+		CREATE (item:CatalogueItem {
+			uid: $itemUID,
+			name: 'Original Item',
+			catalogueNumber: 'CN-ORIG',
+			description: 'original description',
+			lastUpdateTime: datetime()
+		})
+		CREATE (item)-[:BELONGS_TO_CATEGORY]->(cat)
+		CREATE (item)-[:HAS_SUPPLIER]->(supp)
+		CREATE (item)-[:HAS_CATALOGUE_PROPERTY {value: '12'}]->(propA)
+		CREATE (item)-[:HAS_CATALOGUE_PROPERTY {value: '50'}]->(propB)
+		CREATE (item)-[:HAS_CATALOGUE_PROPERTY {value: 'keep'}]->(propC)
+		CREATE (item)-[:WAS_UPDATED_BY{at: datetime(), action: 'INSERT'}]->(u)
+	`, map[string]interface{}{
+		"itemUID":     f.itemUID,
+		"categoryUID": f.categoryUID,
+		"category2":   f.category2,
+		"supplierUID": f.supplierUID,
+		"supplier2":   f.supplier2,
+		"userUID":     f.userUID,
+		"propAUID":    f.propAUID,
+		"propBUID":    f.propBUID,
+		"propCUID":    f.propCUID,
+		"grpUID":      f.grpUID,
+	})
+	assert.NoError(t, err)
+
+	return f
+}
+
+func cleanupPatchFixture(f patchFixture) {
+	testsetup.TestSession.Run(`
+		MATCH (n) WHERE n.uid IN [
+			$itemUID, $categoryUID, $category2, $supplierUID, $supplier2, $userUID,
+			$propAUID, $propBUID, $propCUID, $grpUID
+		] DETACH DELETE n
+	`, map[string]interface{}{
+		"itemUID":     f.itemUID,
+		"categoryUID": f.categoryUID,
+		"category2":   f.category2,
+		"supplierUID": f.supplierUID,
+		"supplier2":   f.supplier2,
+		"userUID":     f.userUID,
+		"propAUID":    f.propAUID,
+		"propBUID":    f.propBUID,
+		"propCUID":    f.propCUID,
+		"grpUID":      f.grpUID,
+	})
+}
+
+func newPatchSvc() *CatalogueService {
+	return &CatalogueService{neo4jDriver: &testsetup.TestDriver, jwtSecret: config.Config{}.JwtSecret}
+}
+
+func readLatestChanges(t *testing.T, itemUID string) (string, string) {
+	t.Helper()
+	res, err := testsetup.TestSession.Run(`
+		MATCH (i:CatalogueItem{uid: $uid})-[r:WAS_UPDATED_BY]->()
+		WHERE r.action = 'PATCH'
+		RETURN r.changes as changes, r.action as action
+		ORDER BY r.at DESC LIMIT 1
+	`, map[string]interface{}{"uid": itemUID})
+	assert.NoError(t, err)
+	if res.Next() {
+		rec := res.Record()
+		changes, _ := rec.Get("changes")
+		action, _ := rec.Get("action")
+		s, _ := changes.(string)
+		a, _ := action.(string)
+		return s, a
+	}
+	return "", ""
+}
+
+func TestPatchCatalogueItem_UpdatesNameOnly(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, err := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	assert.NoError(t, err)
+
+	newName := "Patched Name"
+	fields := &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: original.LastUpdateTime,
+	}
+
+	updated, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+	assert.Equal(t, "Patched Name", updated.Name)
+	assert.Equal(t, "CN-ORIG", updated.CatalogueNumber, "catalogueNumber must not change")
+	assert.NotNil(t, updated.Description)
+	assert.Equal(t, "original description", *updated.Description)
+	assert.Len(t, updated.Details, 3, "all 3 details must remain intact")
+	assert.NotNil(t, updated.Supplier)
+	assert.Equal(t, f.supplierUID, updated.Supplier.UID, "supplier must not change")
+
+	changes, action := readLatestChanges(t, f.itemUID)
+	assert.Equal(t, "PATCH", action)
+	var parsed []map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "name", parsed[0]["field"])
+}
+
+func TestPatchCatalogueItem_UpdatesOneDetailOnly(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	details := []models.CatalogueItemDetail{{
+		Property: models.CatalogueCategoryProperty{UID: f.propAUID, Name: "Voltage", Type: models.CatalogueCategoryPropertyType{Code: "text"}},
+		Value:    "24",
+	}}
+	fields := &models.PatchCatalogueItemFields{
+		Details:        &details,
+		LastUpdateTime: original.LastUpdateTime,
+	}
+
+	updated, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+	assert.Len(t, updated.Details, 3, "all 3 details must remain")
+
+	byUID := map[string]string{}
+	for _, d := range updated.Details {
+		if v, ok := d.Value.(string); ok {
+			byUID[d.Property.UID] = v
+		}
+	}
+	assert.Equal(t, "24", byUID[f.propAUID], "Voltage updated")
+	assert.Equal(t, "50", byUID[f.propBUID], "Weight untouched")
+	assert.Equal(t, "keep", byUID[f.propCUID], "Note untouched")
+
+	changes, _ := readLatestChanges(t, f.itemUID)
+	var parsed []map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "Voltage", parsed[0]["field"])
+	assert.Equal(t, "12", parsed[0]["oldValue"])
+	assert.Equal(t, "24", parsed[0]["newValue"])
+}
+
+func TestPatchCatalogueItem_StaleTimestamp_Returns409(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+	stale := original.LastUpdateTime.AddDate(-1, 0, 0)
+
+	newName := "X"
+	_, err := svc.PatchCatalogueItem(f.itemUID, &models.PatchCatalogueItemFields{
+		Name:           &newName,
+		LastUpdateTime: stale,
+	}, f.userUID)
+	assert.ErrorIs(t, err, helpers.ERR_CONFLICT)
+}
+
+func TestPatchCatalogueItem_NullDescription_Clears(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	fields := &models.PatchCatalogueItemFields{
+		Description:    &models.Optional[string]{Value: nil},
+		LastUpdateTime: original.LastUpdateTime,
+	}
+	updated, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+	assert.Nil(t, updated.Description, "description should be cleared to null")
+
+	changes, _ := readLatestChanges(t, f.itemUID)
+	var parsed []map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "description", parsed[0]["field"])
+	assert.Nil(t, parsed[0]["newValue"])
+}
+
+func TestPatchCatalogueItem_IdempotentCall_EmptyChanges(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	sameName := original.Name
+	fields := &models.PatchCatalogueItemFields{
+		Name:           &sameName,
+		LastUpdateTime: original.LastUpdateTime,
+	}
+	_, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+
+	changes, action := readLatestChanges(t, f.itemUID)
+	assert.Equal(t, "PATCH", action)
+	assert.Equal(t, "[]", changes, "idempotent PATCH should record empty changes array")
+}
+
+func TestPatchCatalogueItem_SupplierRelReplacement(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	fields := &models.PatchCatalogueItemFields{
+		Supplier:       &models.Optional[codebookModels.Codebook]{Value: &codebookModels.Codebook{UID: f.supplier2, Name: "PatchSupplier2"}},
+		LastUpdateTime: original.LastUpdateTime,
+	}
+	updated, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+	assert.NotNil(t, updated.Supplier)
+	assert.Equal(t, f.supplier2, updated.Supplier.UID)
+
+	changes, _ := readLatestChanges(t, f.itemUID)
+	var parsed []map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "supplier", parsed[0]["field"])
+	assert.Equal(t, "codebook", parsed[0]["type"])
+}
+
+func TestPatchCatalogueItem_CategoryReplacement(t *testing.T) {
+	f := seedPatchFixture(t)
+	defer cleanupPatchFixture(f)
+	svc := newPatchSvc()
+
+	original, _ := svc.GetCatalogueItemWithDetailsByUid(f.itemUID)
+
+	fields := &models.PatchCatalogueItemFields{
+		Category:       &codebookModels.Codebook{UID: f.category2, Name: "PatchTestCat2"},
+		LastUpdateTime: original.LastUpdateTime,
+	}
+	updated, err := svc.PatchCatalogueItem(f.itemUID, fields, f.userUID)
+	assert.NoError(t, err)
+	assert.Equal(t, f.category2, updated.Category.UID)
+
+	changes, _ := readLatestChanges(t, f.itemUID)
+	var parsed []map[string]interface{}
+	assert.NoError(t, json.Unmarshal([]byte(changes), &parsed))
+	assert.Len(t, parsed, 1)
+	assert.Equal(t, "category", parsed[0]["field"])
+	assert.Equal(t, "codebook", parsed[0]["type"])
+}
+
+func TestParsePatchCatalogueItemPayload_RequiresLastUpdateTime(t *testing.T) {
+	raw := map[string]json.RawMessage{"name": json.RawMessage(`"X"`)}
+	_, err := parsePatchCatalogueItemPayload(raw)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "lastUpdateTime")
+}
+
+func TestParsePatchCatalogueItemPayload_NullDescription(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+		"description":    json.RawMessage(`null`),
+	}
+	fields, err := parsePatchCatalogueItemPayload(raw)
+	assert.NoError(t, err)
+	assert.NotNil(t, fields.Description)
+	assert.Nil(t, fields.Description.Value, "explicit null maps to Optional with nil Value")
+}
+
+func TestParsePatchCatalogueItemPayload_AbsentDescription(t *testing.T) {
+	raw := map[string]json.RawMessage{
+		"lastUpdateTime": json.RawMessage(`"2026-04-21T10:00:00Z"`),
+	}
+	fields, err := parsePatchCatalogueItemPayload(raw)
+	assert.NoError(t, err)
+	assert.Nil(t, fields.Description, "absent key maps to nil Optional pointer")
+}

--- a/services/catalogue-service/models/model_catalogue_item.go
+++ b/services/catalogue-service/models/model_catalogue_item.go
@@ -65,6 +65,28 @@ type CatalogueItemSimple struct {
 	LastUpdateBy *string `json:"lastUpdateBy"`
 }
 
+// Optional signals presence of a field in a PATCH payload.
+// A nil *Optional pointer means the JSON key was absent; a non-nil pointer with
+// Value == nil means the JSON key was explicitly null (clear operation).
+type Optional[T any] struct {
+	Value *T
+}
+
+// PatchCatalogueItemFields is the parsed PATCH request body passed from handler to service.
+// Each field uses either a plain pointer (nil = absent) or *Optional[T] (nil = absent;
+// non-nil with Value=nil = explicit null clear) depending on whether the field is nullable.
+type PatchCatalogueItemFields struct {
+	Name               *string
+	CatalogueNumber    *string
+	Description        *Optional[string]
+	ManufacturerUrl    *Optional[string]
+	ManufacturerNumber *Optional[string]
+	Supplier           *Optional[models.Codebook]
+	Category           *models.Codebook
+	Details            *[]CatalogueItemDetail
+	LastUpdateTime     time.Time
+}
+
 type CatalogueItemDetailSimple struct {
 	PropertyName string `json:"propertyName,omitempty"`
 

--- a/services/publications-service/publications-handlers.go
+++ b/services/publications-service/publications-handlers.go
@@ -3,6 +3,7 @@ package publicationsservice
 import (
 	"encoding/csv"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/publications-service/models"
@@ -136,8 +137,7 @@ func (h *PublicationsHandlers) GetPublication() echo.HandlerFunc {
 
 		publication, err := h.PublicationsService.GetPublicationByUid(uid)
 		if err != nil {
-			// return 404 if not found - in error message will be result contains no more records
-			if err.Error() == "Result contains no more records" {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
 				return echo.ErrNotFound
 			}
 			log.Error().Err(err).Msg("Error getting publication")
@@ -717,8 +717,7 @@ func (h *PublicationsHandlers) GetResearcher() echo.HandlerFunc {
 
 		researcher, err := h.PublicationsService.GetResearcherByUid(uid)
 		if err != nil {
-			// return 404 if not found - in error message will be result contains no more records
-			if err.Error() == "Result contains no more records" {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
 				return echo.ErrNotFound
 			}
 			log.Error().Err(err).Msg("Error getting researcher")
@@ -926,7 +925,7 @@ func (h *PublicationsHandlers) GetGrant() echo.HandlerFunc {
 
 		grant, err := h.PublicationsService.GetGrantByUid(uid)
 		if err != nil {
-			if err.Error() == "Result contains no more records" {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
 				return echo.ErrNotFound
 			}
 			log.Error().Err(err).Msg("Error getting grant")

--- a/services/room-cards-service/room-cards-handlers.go
+++ b/services/room-cards-service/room-cards-handlers.go
@@ -1,6 +1,7 @@
 package roomcardsservice
 
 import (
+	"errors"
 	"net/http"
 	"panda/apigateway/helpers"
 
@@ -71,8 +72,7 @@ func (h *RoomCardsHandlers) GetLayoutRoomCardInfo() echo.HandlerFunc {
 
 		result, err := h.RoomCardsService.GetLayoutRoomCardInfo(locationCode)
 		if err != nil {
-			// return 404 if not found - in error message will be result contains no more records
-			if err.Error() == "Result contains no more records" {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
 				return echo.ErrNotFound
 			}
 			log.Error().Err(err).Msg("Error getting room cards for location")

--- a/services/zone-service/zone-service.go
+++ b/services/zone-service/zone-service.go
@@ -335,7 +335,7 @@ func validateParentIsRoot(session neo4j.Session, parentUID, facilityCode string)
 }
 
 func isNoRecords(err error) bool {
-	return err != nil && strings.Contains(err.Error(), "no more records")
+	return errors.Is(err, helpers.ERR_NO_ROWS)
 }
 
 func mapCSVColumns(header []string) map[string]int {


### PR DESCRIPTION
## Summary

- Adds `PATCH /v1/catalogue/item/:uid` — partial update following JSON Merge Patch (RFC 7396). Existing `PUT` stays unchanged.
- Introduces reusable `helpers.ChangeEntry` audit-trail helper (field/type/oldValue/newValue). Writes a JSON-stringified changes array onto `WAS_UPDATED_BY.changes` — the write-side pairing with the read-side already added in `f25495e` for `SystemHistory.Changes`.
- Supported fields: `name`, `catalogueNumber`, `description`, `manufacturerUrl`, `manufacturerNumber`, `supplier`, `category`, `details`. `lastUpdateTime` required; conflict → 409.

## Semantics

- Missing JSON key → field untouched.
- Explicit JSON `null` on nullable scalar → cleared in DB.
- `details` array: each entry MERGE+SET; properties not in the payload stay as they are (no destructive delete). To clear a single detail, send `{value: null}`.
- `supplier: null` → removes HAS_SUPPLIER relationship.
- `category: {uid: X}` → switches BELONGS_TO_CATEGORY. FE is responsible for clearing non-relevant details after a category change.
- Idempotent PATCH (no actual field change) still records `WAS_UPDATED_BY` with `changes: "[]"`.

## Change entry mapping

| Field | Type in entry |
|---|---|
| scalar strings | `string` |
| supplier / category | `codebook` (compared by UID) |
| detail value | maps from `Property.Type.Code` (text/list→string, number→number, range→stringified JSON) |

`field` for details uses `Property.Name` (human-readable).

## Files

- `helpers/change_tracking.go` (new) — ChangeEntry, ChangeType, AppendIfChanged, MarshalChanges.
- `services/catalogue-service/catalogue-db-queries.go` — `PatchCatalogueItemQuery` builder.
- `services/catalogue-service/catalogue-service.go` — service method + interface entry.
- `services/catalogue-service/catalogue-handlers.go` — handler with `map[string]json.RawMessage` parsing (distinguishes absent vs null).
- `services/catalogue-service/catalogue-routes.go` — PATCH route registration under `ROLE_CATALOGUE_EDIT`.
- `services/catalogue-service/models/model_catalogue_item.go` — internal `PatchCatalogueItemFields` + generic `Optional[T]`.

## Test plan

- [x] `go test ./helpers/...` — 12 unit tests covering ChangeEntry helpers pass
- [x] `go test ./services/catalogue-service/...` — 10 query builder unit tests + 7 integration tests against real Neo4j pass
- [x] `make build` — compiles cleanly
- [x] `make swagger` — PATCH endpoint appears in `docs/swagger.json`
- [ ] Manual smoke test: `curl -X PATCH -d '{"name":"X","lastUpdateTime":"<iso>"}'` on staging
- [ ] Regression: existing `PUT /v1/catalogue/item/:uid` still works for full-object updates

## Notes for reviewer

- `category` changes are intentionally non-destructive — old details (which may reference properties not in the new category) are preserved. FE should clear them explicitly if desired.
- `AutoResolveObjectToUpdateQuery` was deliberately **not** used — its reflection on non-pointer `string` fields is the root cause PATCH needed a separate builder.
- The `changes` write-side here is the first producer in the project; `systems-service` could adopt the same pattern next.