### PR TITLE
feat(systems): align relationship types with FE PR #1072

### DIFF
--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
@@ -1,3 +1,6 @@
+// See up.cypher for uniqueness invariant rationale; same reasoning applies
+// to the rollback direction.
+
 MATCH (s)-[r:IS_POWERED_FROM]->(t)
 MERGE (s)-[r2:IS_POWERED_BY]->(t)
 ON CREATE SET r2 = properties(r)

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
@@ -1,0 +1,9 @@
+MATCH (s)-[r:IS_POWERED_FROM]->(t)
+CREATE (s)-[r2:IS_POWERED_BY]->(t)
+SET r2 = properties(r)
+DELETE r;
+
+MATCH (s)-[r:IS_COOLED_FROM]->(t)
+CREATE (s)-[r2:IS_COOLED_BY]->(t)
+SET r2 = properties(r)
+DELETE r;

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
@@ -1,9 +1,9 @@
 MATCH (s)-[r:IS_POWERED_FROM]->(t)
-CREATE (s)-[r2:IS_POWERED_BY]->(t)
-SET r2 = properties(r)
+MERGE (s)-[r2:IS_POWERED_BY]->(t)
+ON CREATE SET r2 = properties(r)
 DELETE r;
 
 MATCH (s)-[r:IS_COOLED_FROM]->(t)
-CREATE (s)-[r2:IS_COOLED_BY]->(t)
-SET r2 = properties(r)
+MERGE (s)-[r2:IS_COOLED_BY]->(t)
+ON CREATE SET r2 = properties(r)
 DELETE r;

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
@@ -1,0 +1,9 @@
+MATCH (s)-[r:IS_POWERED_BY]->(t)
+CREATE (s)-[r2:IS_POWERED_FROM]->(t)
+SET r2 = properties(r)
+DELETE r;
+
+MATCH (s)-[r:IS_COOLED_BY]->(t)
+CREATE (s)-[r2:IS_COOLED_FROM]->(t)
+SET r2 = properties(r)
+DELETE r;

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
@@ -1,3 +1,11 @@
+// Uniqueness invariant: at most one IS_POWERED_BY/IS_COOLED_BY edge exists
+// between any pair of systems, enforced by the batch create endpoint
+// (services/systems-service: CreateBatchRelationships uses
+// OPTIONAL MATCH ... existFwd IS NULL guard before CREATE).
+// MERGE here is therefore safe to dedupe; if duplicates do exist (e.g. from
+// manual data entry), they collapse into one new edge and inherit the
+// properties of whichever legacy edge was matched first.
+
 MATCH (s)-[r:IS_POWERED_BY]->(t)
 MERGE (s)-[r2:IS_POWERED_FROM]->(t)
 ON CREATE SET r2 = properties(r)

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
@@ -1,9 +1,9 @@
 MATCH (s)-[r:IS_POWERED_BY]->(t)
-CREATE (s)-[r2:IS_POWERED_FROM]->(t)
-SET r2 = properties(r)
+MERGE (s)-[r2:IS_POWERED_FROM]->(t)
+ON CREATE SET r2 = properties(r)
 DELETE r;
 
 MATCH (s)-[r:IS_COOLED_BY]->(t)
-CREATE (s)-[r2:IS_COOLED_FROM]->(t)
-SET r2 = properties(r)
+MERGE (s)-[r2:IS_COOLED_FROM]->(t)
+ON CREATE SET r2 = properties(r)
 DELETE r;

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -2432,9 +2432,8 @@ func CreateNewSystemRelationshipQuery(newRelationship *models.SystemRelationship
 	CREATE(fromSystem)-[newRel:IS_SPARE_FOR]->(toSystem)
 	WITH fromSystem, toSystem, u, newRel
 	CREATE(fromSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)
-	WITH fromSystem, toSystem, newRel
+	WITH fromSystem, toSystem, u, newRel
 	CREATE(toSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)
-	WITH fromSystem, toSystem, newRel
 	RETURN id(newRel) as result`
 
 	result.ReturnAlias = "result"

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -2418,7 +2418,6 @@ func CreateNewSystemRelationshipQuery(newRelationship *models.SystemRelationship
 
 	result.Parameters = make(map[string]interface{})
 	result.Parameters["facilityCode"] = facilityCode
-	result.Parameters["uid"] = uuid.NewString()
 	result.Parameters["fromSystemUID"] = newRelationship.SystemFromUID
 	result.Parameters["toSystemUID"] = newRelationship.SystemToUID
 	result.Parameters["lastUpdateBy"] = userUID

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -2424,27 +2424,19 @@ func CreateNewSystemRelationshipQuery(newRelationship *models.SystemRelationship
 	result.Parameters["relationshipTypeCode"] = newRelationship.RelationTypeCode
 	result.Parameters["lastUpdateBy"] = userUID
 
+	// Single endpoint only supports IS_SPARE_FOR; service layer enforces.
 	result.Query = `
-	MATCH(f:Facility{code: $facilityCode}) WITH f	
+	MATCH(f:Facility{code: $facilityCode}) WITH f
 	MATCH(u:User{uid: $lastUpdateBy}) WITH u, f
 	MATCH(fromSystem:System{uid: $fromSystemUID, deleted: false})-[:BELONGS_TO_FACILITY]->(f)
-	MATCH(toSystem:System{uid: $toSystemUID, deleted: false})-[:BELONGS_TO_FACILITY]->(f)`
-
-	if newRelationship.RelationTypeCode == "IS_SPARE_FOR" {
-		result.Query += `CREATE(fromSystem)-[newRel:IS_SPARE_FOR]->(toSystem) `
-	} else {
-		result.Query += `REALTIONSHIP NOT DEFINED`
-	}
-
-	result.Query += `
+	MATCH(toSystem:System{uid: $toSystemUID, deleted: false})-[:BELONGS_TO_FACILITY]->(f)
+	CREATE(fromSystem)-[newRel:IS_SPARE_FOR]->(toSystem)
 	WITH fromSystem, toSystem, u, newRel
-	CREATE(fromSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)	
+	CREATE(fromSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)
 	WITH fromSystem, toSystem, newRel
-	CREATE(toSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)	
+	CREATE(toSystem)-[:WAS_UPDATED_BY{ at: datetime(), action: "UPDATE" }]->(u)
 	WITH fromSystem, toSystem, newRel
-	`
-
-	result.Query += `RETURN id(newRel) as result`
+	RETURN id(newRel) as result`
 
 	result.ReturnAlias = "result"
 

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -2421,7 +2421,6 @@ func CreateNewSystemRelationshipQuery(newRelationship *models.SystemRelationship
 	result.Parameters["uid"] = uuid.NewString()
 	result.Parameters["fromSystemUID"] = newRelationship.SystemFromUID
 	result.Parameters["toSystemUID"] = newRelationship.SystemToUID
-	result.Parameters["relationshipTypeCode"] = newRelationship.RelationTypeCode
 	result.Parameters["lastUpdateBy"] = userUID
 
 	// Single endpoint only supports IS_SPARE_FOR; service layer enforces.

--- a/services/systems-service/systems-db-queries_graph_test.go
+++ b/services/systems-service/systems-db-queries_graph_test.go
@@ -15,7 +15,7 @@ func TestGetSystemGraphNodesByUidsQuery(t *testing.T) {
 }
 
 func TestGetSystemGraphFilteredLinksByUidQuery(t *testing.T) {
-	query := GetSystemGraphFilteredLinksByUidQuery("sys-1", "B", []string{"HAS_SUBSYSTEM", "IS_POWERED_BY"}, "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
+	query := GetSystemGraphFilteredLinksByUidQuery("sys-1", "B", []string{"HAS_SUBSYSTEM", "IS_POWERED_FROM"}, "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
 
 	assert.Equal(t, "links", query.ReturnAlias)
 	assert.Contains(t, query.Query, "uid: toString(id(r))")
@@ -33,7 +33,7 @@ func TestGetSystemGraphFilteredLinksByUidQuery(t *testing.T) {
 }
 
 func TestGetSystemGraphLinksByUidAndTypeFilteredQuery_HasStablePagingOrder(t *testing.T) {
-	query := GetSystemGraphLinksByUidAndTypeFilteredQuery("sys-1", "B", "IS_POWERED_BY", "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling", 20, 10)
+	query := GetSystemGraphLinksByUidAndTypeFilteredQuery("sys-1", "B", "IS_POWERED_FROM", "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling", 20, 10)
 
 	assert.Equal(t, "links", query.ReturnAlias)
 	assert.Contains(t, query.Query, "ORDER BY link.relId ASC")
@@ -52,7 +52,7 @@ func TestGetSystemGraphLinksByUidAndTypeFilteredQuery_HasStablePagingOrder(t *te
 }
 
 func TestGetSystemGraphLinksByUidAndTypeFilteredCountQuery(t *testing.T) {
-	query := GetSystemGraphLinksByUidAndTypeFilteredCountQuery("sys-1", "B", "IS_POWERED_BY", "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
+	query := GetSystemGraphLinksByUidAndTypeFilteredCountQuery("sys-1", "B", "IS_POWERED_FROM", "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
 
 	assert.Equal(t, "totalCount", query.ReturnAlias)
 	assert.Contains(t, query.Query, "count(DISTINCT relationId) as totalCount")
@@ -65,7 +65,7 @@ func TestGetSystemGraphLinksByUidAndTypeFilteredCountQuery(t *testing.T) {
 }
 
 func TestGetSystemGraphFilteredCountsByTypesQuery(t *testing.T) {
-	query := GetSystemGraphFilteredCountsByTypesQuery("sys-1", "B", []string{"HAS_SUBSYSTEM", "IS_POWERED_BY"}, "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
+	query := GetSystemGraphFilteredCountsByTypesQuery("sys-1", "B", []string{"HAS_SUBSYSTEM", "IS_POWERED_FROM"}, "pump", []string{"TECHNOLOGY_UNIT"}, "Cooling")
 
 	assert.Equal(t, "counts", query.ReturnAlias)
 	assert.Contains(t, query.Query, "WITH relationship, count(DISTINCT relationId) as total")

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -1008,7 +1008,8 @@ func (h *SystemsHandlers) CreateNewSystemRelationship() echo.HandlerFunc {
 		}
 
 		if errors.Is(err, helpers.ERR_INVALID_INPUT) {
-			return helpers.BadRequest(err.Error())
+			msg := strings.TrimSuffix(err.Error(), ": "+helpers.ERR_INVALID_INPUT.Error())
+			return helpers.BadRequest(msg)
 		}
 
 		log.Error().Msg(err.Error())

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -775,7 +775,7 @@ func parseSystemGraphQueryOptions(c echo.Context) (options models.SystemGraphQue
 		return options, err
 	}
 	for _, relationship := range relationshipTypes {
-		if !isAllowedSystemGraphRelationshipType(relationship) {
+		if !isAllowedSystemRelationshipType(relationship) {
 			return options, errors.New("invalid relationshipTypes")
 		}
 	}
@@ -803,7 +803,7 @@ func parseSystemGraphQueryOptions(c echo.Context) (options models.SystemGraphQue
 			return options, errors.New("relationshipType cannot be combined with limitPerRelationshipType")
 		}
 
-		if !isAllowedSystemGraphRelationshipType(relationshipType) {
+		if !isAllowedSystemRelationshipType(relationshipType) {
 			return options, errors.New("invalid relationshipType")
 		}
 

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -994,23 +994,25 @@ func (h *SystemsHandlers) CreateNewSystemRelationship() echo.HandlerFunc {
 		// lets bind catalogue category data from request body
 		systemRelationshipRequest := new(models.SystemRelationshipRequest)
 		err := c.Bind(systemRelationshipRequest)
-		if err == nil {
-
-			userUID := c.Get("userUID").(string)
-			facilityCode := c.Get("facilityCode").(string)
-
-			newId, err := h.systemsService.CreateNewSystemRelationship(systemRelationshipRequest, facilityCode, userUID)
-
-			if err == nil {
-				return c.String(http.StatusCreated, strconv.FormatInt(newId, 10))
-			}
-
-			return echo.ErrInternalServerError
-
-		} else {
+		if err != nil {
 			log.Error().Msg(err.Error())
+			return helpers.BadRequest(err.Error())
 		}
-		return helpers.BadRequest(err.Error())
+
+		userUID := c.Get("userUID").(string)
+		facilityCode := c.Get("facilityCode").(string)
+
+		newId, err := h.systemsService.CreateNewSystemRelationship(systemRelationshipRequest, facilityCode, userUID)
+		if err == nil {
+			return c.String(http.StatusCreated, strconv.FormatInt(newId, 10))
+		}
+
+		if errors.Is(err, helpers.ERR_INVALID_INPUT) {
+			return helpers.BadRequest(err.Error())
+		}
+
+		log.Error().Msg(err.Error())
+		return echo.ErrInternalServerError
 	}
 }
 

--- a/services/systems-service/systems-handlers_graph_test.go
+++ b/services/systems-service/systems-handlers_graph_test.go
@@ -43,7 +43,7 @@ func TestParseSystemGraphQueryOptions_InitialMode(t *testing.T) {
 }
 
 func TestParseSystemGraphQueryOptions_FilteredMode(t *testing.T) {
-	c := newGraphQueryContext("search=power&systemLevels=technology_unit,key_systems&systemType=Cooling&relationshipTypes=is_powered_by,has_subsystem")
+	c := newGraphQueryContext("search=power&systemLevels=technology_unit,key_systems&systemType=Cooling&relationshipTypes=is_powered_from,has_subsystem")
 
 	options, err := parseSystemGraphQueryOptions(c)
 
@@ -51,13 +51,13 @@ func TestParseSystemGraphQueryOptions_FilteredMode(t *testing.T) {
 	assert.Equal(t, "power", options.Search)
 	assert.Equal(t, []string{"TECHNOLOGY_UNIT", "KEY_SYSTEMS"}, options.SystemLevels)
 	assert.Equal(t, "Cooling", options.SystemType)
-	assert.Equal(t, []string{"IS_POWERED_BY", "HAS_SUBSYSTEM"}, options.RelationshipTypes)
+	assert.Equal(t, []string{"IS_POWERED_FROM", "HAS_SUBSYSTEM"}, options.RelationshipTypes)
 	assert.Nil(t, options.LimitPerRelationshipType)
 	assert.Equal(t, "", options.RelationshipType)
 }
 
 func TestParseSystemGraphQueryOptions_RelationshipTypeWithLimitPerTypeIsInvalid(t *testing.T) {
-	c := newGraphQueryContext("relationshipType=IS_POWERED_BY&offset=20&limit=10&limitPerRelationshipType=20")
+	c := newGraphQueryContext("relationshipType=IS_POWERED_FROM&offset=20&limit=10&limitPerRelationshipType=20")
 
 	_, err := parseSystemGraphQueryOptions(c)
 
@@ -65,7 +65,7 @@ func TestParseSystemGraphQueryOptions_RelationshipTypeWithLimitPerTypeIsInvalid(
 }
 
 func TestParseSystemGraphQueryOptions_InvalidOffset(t *testing.T) {
-	c := newGraphQueryContext("relationshipType=IS_POWERED_BY&offset=-1")
+	c := newGraphQueryContext("relationshipType=IS_POWERED_FROM&offset=-1")
 
 	_, err := parseSystemGraphQueryOptions(c)
 
@@ -89,12 +89,12 @@ func TestParseSystemGraphQueryOptions_InvalidIncludeStats(t *testing.T) {
 }
 
 func TestParseSystemGraphQueryOptions_LoadMoreWithFiltersIsValid(t *testing.T) {
-	c := newGraphQueryContext("relationshipType=IS_POWERED_BY&search=abc")
+	c := newGraphQueryContext("relationshipType=IS_POWERED_FROM&search=abc")
 
 	options, err := parseSystemGraphQueryOptions(c)
 
 	assert.NoError(t, err)
-	assert.Equal(t, "IS_POWERED_BY", options.RelationshipType)
+	assert.Equal(t, "IS_POWERED_FROM", options.RelationshipType)
 	assert.Equal(t, "abc", options.Search)
 }
 

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -1009,6 +1009,10 @@ func (svc *SystemsService) DeleteSystemRelationship(uid int64, userUID string) (
 
 func (svc *SystemsService) CreateNewSystemRelationship(newRelationship *models.SystemRelationshipRequest, facilityCode string, userUID string) (relId int64, err error) {
 
+	if newRelationship.RelationTypeCode != "IS_SPARE_FOR" {
+		return 0, helpers.ERR_INVALID_INPUT
+	}
+
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 	relId, err = helpers.WriteNeo4jAndReturnSingleValue[int64](session, CreateNewSystemRelationshipQuery(newRelationship, facilityCode, userUID))
 

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -603,8 +603,26 @@ var allowedSystemRelationshipTypeSet = func() map[string]bool {
 	return m
 }()
 
+// Batch endpoint excludes HAS_SUBSYSTEM: hierarchy edges have single-parent /
+// acyclic invariants enforced elsewhere; bypassing them via batch could corrupt
+// the system tree.
+var allowedBatchRelationshipTypeSet = func() map[string]bool {
+	m := make(map[string]bool, len(allowedSystemRelationshipTypes))
+	for _, t := range allowedSystemRelationshipTypes {
+		if t == "HAS_SUBSYSTEM" {
+			continue
+		}
+		m[t] = true
+	}
+	return m
+}()
+
 func isAllowedSystemRelationshipType(relationType string) bool {
 	return allowedSystemRelationshipTypeSet[relationType]
+}
+
+func isAllowedBatchRelationshipType(relationType string) bool {
+	return allowedBatchRelationshipTypeSet[relationType]
 }
 
 type systemGraphRelationshipCount struct {
@@ -1557,7 +1575,7 @@ func (svc *SystemsService) CreateBatchRelationships(request *models.BatchRelatio
 	var response models.BatchRelationshipResponse
 
 	// validate relationship type
-	if !isAllowedSystemRelationshipType(request.RelationshipType) {
+	if !isAllowedBatchRelationshipType(request.RelationshipType) {
 		return response, fmt.Errorf("relationship type '%s' is not allowed", request.RelationshipType)
 	}
 

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -583,22 +583,28 @@ func (svc *SystemsService) GetSystemLeavesByParentUIDCount(parentUID string, fac
 	return count, err
 }
 
-var allowedSystemGraphRelationshipTypes = []string{
+var allowedSystemRelationshipTypes = []string{
 	"HAS_SUBSYSTEM",
-	"IS_COOLED_BY",
-	"IS_POWERED_BY",
 	"IS_SPARE_FOR",
 	"IS_CONTROLLED_BY",
+	"IS_COOLED_FROM",
+	"IS_POWERED_FROM",
+	"IS_INTERLOCKED_BY",
+	"PROVIDES_DATA_TO",
+	"DIRECTS_BEAM_TO",
+	"PROVIDES_VACUUM_FOR",
 }
 
-func isAllowedSystemGraphRelationshipType(relationType string) bool {
-	for _, allowedType := range allowedSystemGraphRelationshipTypes {
-		if relationType == allowedType {
-			return true
-		}
+var allowedSystemRelationshipTypeSet = func() map[string]bool {
+	m := make(map[string]bool, len(allowedSystemRelationshipTypes))
+	for _, t := range allowedSystemRelationshipTypes {
+		m[t] = true
 	}
+	return m
+}()
 
-	return false
+func isAllowedSystemRelationshipType(relationType string) bool {
+	return allowedSystemRelationshipTypeSet[relationType]
 }
 
 type systemGraphRelationshipCount struct {
@@ -637,7 +643,7 @@ func getSystemGraphRelationshipTypes(options models.SystemGraphQueryOptions) []s
 		return options.RelationshipTypes
 	}
 
-	return allowedSystemGraphRelationshipTypes
+	return allowedSystemRelationshipTypes
 }
 
 func isSystemGraphRelationshipTypeAllowedByFilter(relationshipType string, relationshipTypes []string) bool {
@@ -734,7 +740,7 @@ func (svc *SystemsService) GetSystemGraphByUid(uid string, facilityCode string, 
 	}
 
 	if options.RelationshipType != "" {
-		if !isAllowedSystemGraphRelationshipType(options.RelationshipType) {
+		if !isAllowedSystemRelationshipType(options.RelationshipType) {
 			return result, invalidSystemGraphInput("invalid relationshipType")
 		}
 
@@ -943,13 +949,13 @@ func (svc *SystemsService) GetSystemGraphByUid(uid string, facilityCode string, 
 		return result, nil
 	}
 
-	nodesQuery := GetSystemGraphNodesByUidQuery(uid, facilityCode, allowedSystemGraphRelationshipTypes)
+	nodesQuery := GetSystemGraphNodesByUidQuery(uid, facilityCode, allowedSystemRelationshipTypes)
 	nodes, err := helpers.GetNeo4jArrayOfNodes[models.SystemGraphNode](session, nodesQuery)
 	if err != nil {
 		return result, err
 	}
 
-	linksQuery := GetSystemGraphLinksByUidQuery(uid, facilityCode, allowedSystemGraphRelationshipTypes)
+	linksQuery := GetSystemGraphLinksByUidQuery(uid, facilityCode, allowedSystemRelationshipTypes)
 	links, err := helpers.GetNeo4jArrayOfNodes[models.SystemGraphLink](session, linksQuery)
 	if err != nil {
 		return result, err
@@ -1543,18 +1549,11 @@ func (svc *SystemsService) RecalculateSpareParts() (err error) {
 	return err
 }
 
-var allowedBatchRelationshipTypes = map[string]bool{
-	"IS_SPARE_FOR":     true,
-	"IS_COOLED_BY":     true,
-	"IS_POWERED_BY":    true,
-	"IS_CONTROLLED_BY": true,
-}
-
 func (svc *SystemsService) CreateBatchRelationships(request *models.BatchRelationshipRequest, facilityCode, userUID string) (models.BatchRelationshipResponse, error) {
 	var response models.BatchRelationshipResponse
 
 	// validate relationship type
-	if !allowedBatchRelationshipTypes[request.RelationshipType] {
+	if !isAllowedSystemRelationshipType(request.RelationshipType) {
 		return response, fmt.Errorf("relationship type '%s' is not allowed", request.RelationshipType)
 	}
 

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -1028,7 +1028,7 @@ func (svc *SystemsService) DeleteSystemRelationship(uid int64, userUID string) (
 func (svc *SystemsService) CreateNewSystemRelationship(newRelationship *models.SystemRelationshipRequest, facilityCode string, userUID string) (relId int64, err error) {
 
 	if newRelationship.RelationTypeCode != "IS_SPARE_FOR" {
-		return 0, helpers.ERR_INVALID_INPUT
+		return 0, fmt.Errorf("only IS_SPARE_FOR is supported on this endpoint; use /v1/system/relationships/batch for other types: %w", helpers.ERR_INVALID_INPUT)
 	}
 
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)

--- a/services/systems-service/systems-service_graph_test.go
+++ b/services/systems-service/systems-service_graph_test.go
@@ -11,10 +11,50 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestIsAllowedSystemGraphRelationshipType(t *testing.T) {
-	assert.True(t, isAllowedSystemRelationshipType("HAS_SUBSYSTEM"))
-	assert.True(t, isAllowedSystemRelationshipType("IS_COOLED_FROM"))
-	assert.False(t, isAllowedSystemRelationshipType("INVALID_REL"))
+func TestCreateNewSystemRelationship_RejectsNonSpareType(t *testing.T) {
+	svc := &SystemsService{}
+
+	for _, code := range []string{
+		"HAS_SUBSYSTEM",
+		"IS_POWERED_FROM",
+		"IS_CONTROLLED_BY",
+		"PROVIDES_DATA_TO",
+		"",
+		"INVALID",
+	} {
+		req := &models.SystemRelationshipRequest{
+			SystemFromUID:    "sys-a",
+			SystemToUID:      "sys-b",
+			RelationTypeCode: code,
+		}
+		_, err := svc.CreateNewSystemRelationship(req, "B", "user-1")
+		assert.True(t, errors.Is(err, helpers.ERR_INVALID_INPUT), "expected ERR_INVALID_INPUT for code=%q", code)
+	}
+}
+
+func TestIsAllowedSystemRelationshipType(t *testing.T) {
+	for _, allowed := range []string{
+		"HAS_SUBSYSTEM",
+		"IS_SPARE_FOR",
+		"IS_CONTROLLED_BY",
+		"IS_COOLED_FROM",
+		"IS_POWERED_FROM",
+		"IS_INTERLOCKED_BY",
+		"PROVIDES_DATA_TO",
+		"DIRECTS_BEAM_TO",
+		"PROVIDES_VACUUM_FOR",
+	} {
+		assert.True(t, isAllowedSystemRelationshipType(allowed), allowed)
+	}
+
+	for _, rejected := range []string{
+		"IS_POWERED_BY",
+		"IS_COOLED_BY",
+		"INVALID_REL",
+		"",
+	} {
+		assert.False(t, isAllowedSystemRelationshipType(rejected), rejected)
+	}
 }
 
 func TestCollectSystemGraphNodeUIDs(t *testing.T) {

--- a/services/systems-service/systems-service_graph_test.go
+++ b/services/systems-service/systems-service_graph_test.go
@@ -12,9 +12,9 @@ import (
 )
 
 func TestIsAllowedSystemGraphRelationshipType(t *testing.T) {
-	assert.True(t, isAllowedSystemGraphRelationshipType("HAS_SUBSYSTEM"))
-	assert.True(t, isAllowedSystemGraphRelationshipType("IS_COOLED_BY"))
-	assert.False(t, isAllowedSystemGraphRelationshipType("INVALID_REL"))
+	assert.True(t, isAllowedSystemRelationshipType("HAS_SUBSYSTEM"))
+	assert.True(t, isAllowedSystemRelationshipType("IS_COOLED_FROM"))
+	assert.False(t, isAllowedSystemRelationshipType("INVALID_REL"))
 }
 
 func TestCollectSystemGraphNodeUIDs(t *testing.T) {
@@ -42,20 +42,20 @@ func TestGetSystemGraphRelationshipTypes(t *testing.T) {
 	defaultTypes := getSystemGraphRelationshipTypes(models.SystemGraphQueryOptions{})
 
 	assert.Equal(t, []string{"HAS_SUBSYSTEM"}, custom)
-	assert.Equal(t, allowedSystemGraphRelationshipTypes, defaultTypes)
+	assert.Equal(t, allowedSystemRelationshipTypes, defaultTypes)
 }
 
 func TestIsSystemGraphRelationshipTypeAllowedByFilter(t *testing.T) {
 	assert.True(t, isSystemGraphRelationshipTypeAllowedByFilter("HAS_SUBSYSTEM", nil))
-	assert.True(t, isSystemGraphRelationshipTypeAllowedByFilter("HAS_SUBSYSTEM", []string{"HAS_SUBSYSTEM", "IS_POWERED_BY"}))
-	assert.False(t, isSystemGraphRelationshipTypeAllowedByFilter("IS_COOLED_BY", []string{"HAS_SUBSYSTEM"}))
+	assert.True(t, isSystemGraphRelationshipTypeAllowedByFilter("HAS_SUBSYSTEM", []string{"HAS_SUBSYSTEM", "IS_POWERED_FROM"}))
+	assert.False(t, isSystemGraphRelationshipTypeAllowedByFilter("IS_COOLED_FROM", []string{"HAS_SUBSYSTEM"}))
 }
 
 func TestBuildSystemGraphRelationshipStats(t *testing.T) {
 	links := []models.SystemGraphLink{
 		{Relationship: "HAS_SUBSYSTEM"},
 		{Relationship: "HAS_SUBSYSTEM"},
-		{Relationship: "IS_POWERED_BY"},
+		{Relationship: "IS_POWERED_FROM"},
 	}
 
 	stats := buildSystemGraphRelationshipStats(links)
@@ -63,21 +63,21 @@ func TestBuildSystemGraphRelationshipStats(t *testing.T) {
 	assert.Equal(t, int64(2), stats["HAS_SUBSYSTEM"].Total)
 	assert.Equal(t, int64(2), stats["HAS_SUBSYSTEM"].Returned)
 	assert.False(t, stats["HAS_SUBSYSTEM"].HasMore)
-	assert.Equal(t, int64(1), stats["IS_POWERED_BY"].Total)
+	assert.Equal(t, int64(1), stats["IS_POWERED_FROM"].Total)
 }
 
 func TestBuildSystemGraphRelationshipTotalMap(t *testing.T) {
-	relationshipTypes := []string{"HAS_SUBSYSTEM", "IS_POWERED_BY", "IS_COOLED_BY"}
+	relationshipTypes := []string{"HAS_SUBSYSTEM", "IS_POWERED_FROM", "IS_COOLED_FROM"}
 	counts := []systemGraphRelationshipCount{
 		{Relationship: "HAS_SUBSYSTEM", Total: 5},
-		{Relationship: "IS_POWERED_BY", Total: 2},
+		{Relationship: "IS_POWERED_FROM", Total: 2},
 	}
 
 	result := buildSystemGraphRelationshipTotalMap(relationshipTypes, counts)
 
 	assert.Equal(t, int64(5), result["HAS_SUBSYSTEM"])
-	assert.Equal(t, int64(2), result["IS_POWERED_BY"])
-	assert.Equal(t, int64(0), result["IS_COOLED_BY"])
+	assert.Equal(t, int64(2), result["IS_POWERED_FROM"])
+	assert.Equal(t, int64(0), result["IS_COOLED_FROM"])
 }
 
 func TestCalculateSystemGraphHiddenLinksTotal(t *testing.T) {

--- a/services/systems-service/systems-service_graph_test.go
+++ b/services/systems-service/systems-service_graph_test.go
@@ -11,6 +11,25 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestIsAllowedBatchRelationshipType(t *testing.T) {
+	for _, allowed := range []string{
+		"IS_SPARE_FOR",
+		"IS_CONTROLLED_BY",
+		"IS_COOLED_FROM",
+		"IS_POWERED_FROM",
+		"IS_INTERLOCKED_BY",
+		"PROVIDES_DATA_TO",
+		"DIRECTS_BEAM_TO",
+		"PROVIDES_VACUUM_FOR",
+	} {
+		assert.True(t, isAllowedBatchRelationshipType(allowed), allowed)
+	}
+
+	assert.False(t, isAllowedBatchRelationshipType("HAS_SUBSYSTEM"),
+		"HAS_SUBSYSTEM must be excluded from batch (hierarchy invariants)")
+	assert.False(t, isAllowedBatchRelationshipType("INVALID_REL"))
+}
+
 func TestCreateNewSystemRelationship_RejectsNonSpareType(t *testing.T) {
 	svc := &SystemsService{}
 


### PR DESCRIPTION
## Summary
- Unifies systems relationship type whitelist for graph filtering (9 types).
- Batch create endpoint accepts 8 of these types — `HAS_SUBSYSTEM` is intentionally excluded because hierarchy edges have single-parent / acyclic invariants the batch endpoint does not enforce. Use the dedicated subsystem creation endpoints to add `HAS_SUBSYSTEM` edges.
- Renames `IS_POWERED_BY` → `IS_POWERED_FROM`, `IS_COOLED_BY` → `IS_COOLED_FROM`. Adds `IS_INTERLOCKED_BY`, `PROVIDES_DATA_TO`, `DIRECTS_BEAM_TO`, `PROVIDES_VACUUM_FOR`.
- Single POST `/v1/system/relationship/:uid` now returns 400 (was 500 via invalid Cypher) for non-`IS_SPARE_FOR` types, with a clear message pointing clients to the batch endpoint. Removes unreachable `REALTIONSHIP NOT DEFINED` branch + typo. Drops dead `relationshipTypeCode` query parameter.
- Idempotent Neo4j migration renames legacy edges in DB (`MERGE` + `ON CREATE SET` to preserve properties on pre-existing target edges; relies on the uniqueness invariant enforced by the batch create endpoint).

## Final whitelist

| Type | Graph | Batch |
|---|---|---|
| `HAS_SUBSYSTEM` | yes | **no** |
| `IS_SPARE_FOR` | yes | yes |
| `IS_CONTROLLED_BY` | yes | yes |
| `IS_COOLED_FROM` | yes | yes |
| `IS_POWERED_FROM` | yes | yes |
| `IS_INTERLOCKED_BY` | yes | yes |
| `PROVIDES_DATA_TO` | yes | yes |
| `DIRECTS_BEAM_TO` | yes | yes |
| `PROVIDES_VACUUM_FOR` | yes | yes |

## Coordination
Required by FE PR #1072 (kontext-fe). Merge order: this PR → migration runs at BE startup → FE PR.

## Pre-deploy check
Before deploy, query prod Neo4j:
```cypher
MATCH ()-[r]->() WHERE type(r) IN ['IS_POWERED_BY','IS_COOLED_BY'] RETURN type(r), count(r);
```
If result > 0, migration is load-bearing (not no-op).

## Test plan
- [x] `go test ./services/systems-service/...` green
- [ ] `make build && docker-compose -f docker-compose-local.yml up -d --build` — verify migration log line
- [ ] Batch POST each of 8 batch-allowed codes → 200, `created == 1`
- [ ] Batch POST `HAS_SUBSYSTEM` → 400 (`relationship type 'HAS_SUBSYSTEM' is not allowed`)
- [ ] `GET /v1/system/{uid}/graph?relationshipTypes=PROVIDES_DATA_TO` returns only those edges
- [ ] `meta.relationshipStats` shows new types when present
- [ ] Single POST with `IS_POWERED_FROM` → 400 (regression: was 500)
- [ ] Single POST with `IS_SPARE_FOR` → 201 (regression check)
- [ ] Post-migration: `MATCH ()-[r:IS_POWERED_BY]->() RETURN count(r)` → 0