### PR TITLE
fix(db): hot-fix broken relationship rename migration from PR #411

### DIFF
--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.down.cypher
@@ -1,12 +1,7 @@
-// See up.cypher for uniqueness invariant rationale; same reasoning applies
-// to the rollback direction.
-
 MATCH (s)-[r:IS_POWERED_FROM]->(t)
-MERGE (s)-[r2:IS_POWERED_BY]->(t)
-ON CREATE SET r2 = properties(r)
-DELETE r;
+CALL apoc.refactor.setType(r, 'IS_POWERED_BY') YIELD input, output
+RETURN count(output);
 
 MATCH (s)-[r:IS_COOLED_FROM]->(t)
-MERGE (s)-[r2:IS_COOLED_BY]->(t)
-ON CREATE SET r2 = properties(r)
-DELETE r;
+CALL apoc.refactor.setType(r, 'IS_COOLED_BY') YIELD input, output
+RETURN count(output);

--- a/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
+++ b/db/neo4j/migrations/20260430120000_rename_legacy_relationship_types.up.cypher
@@ -1,17 +1,7 @@
-// Uniqueness invariant: at most one IS_POWERED_BY/IS_COOLED_BY edge exists
-// between any pair of systems, enforced by the batch create endpoint
-// (services/systems-service: CreateBatchRelationships uses
-// OPTIONAL MATCH ... existFwd IS NULL guard before CREATE).
-// MERGE here is therefore safe to dedupe; if duplicates do exist (e.g. from
-// manual data entry), they collapse into one new edge and inherit the
-// properties of whichever legacy edge was matched first.
-
 MATCH (s)-[r:IS_POWERED_BY]->(t)
-MERGE (s)-[r2:IS_POWERED_FROM]->(t)
-ON CREATE SET r2 = properties(r)
-DELETE r;
+CALL apoc.refactor.setType(r, 'IS_POWERED_FROM') YIELD input, output
+RETURN count(output);
 
 MATCH (s)-[r:IS_COOLED_BY]->(t)
-MERGE (s)-[r2:IS_COOLED_FROM]->(t)
-ON CREATE SET r2 = properties(r)
-DELETE r;
+CALL apoc.refactor.setType(r, 'IS_COOLED_FROM') YIELD input, output
+RETURN count(output);


### PR DESCRIPTION
## Summary
Hot-fix for the relationship rename migration introduced in #411. The migration crashes Neo4j's parser at API startup, leaving the DB in a `dirty` state and preventing the BE from booting.

## Error
\`\`\`
[Neo.ClientError.Statement.SyntaxError] Unexpected end of input:
expected CYPHER, EXPLAIN, PROFILE or Query (line 0, column 1 (offset: 1))
"// Uniqueness invariant: at most one IS_POWERED_BY/IS_COOLED_BY edge exists"
\`\`\`

## Root cause
golang-migrate's multi-statement splitter forwards the file content to Neo4j; the leading orphan `//` comment block (before any statement) trips the Cypher parser in Neo4j 4.4. Other working migrations in this repo only use `//` inline with statements, never as a leading block.

## Fix
- Drop the leading comment block.
- Switch from MERGE/DELETE pattern to `apoc.refactor.setType` — atomic per-edge rename, idempotent, properties preserved automatically.

## Recovery for affected environments
Any environment that already booted the broken migration has a `dirty` SchemaMigration node. Before deploying this fix, run on that env's Neo4j:
\`\`\`cypher
MATCH (n:SchemaMigration {version: 20260430120000, dirty: true}) DELETE n;
\`\`\`
Then redeploy. Migration re-runs cleanly against fixed content.

## Test plan
- [x] Local: `make run` starts cleanly, `Migrations OK`
- [ ] Dev server: clear dirty node → deploy → verify startup + post-rename counts