### PR TITLE
fix(catalogue): items sort whitelist + custom property UID

### DIFF
--- a/db/neo4j/migrations/20260511120000_add_catalogue_category_property_uid_index.down.cypher
+++ b/db/neo4j/migrations/20260511120000_add_catalogue_category_property_uid_index.down.cypher
@@ -1,0 +1,1 @@
+DROP INDEX CatalogueCategoryProperty_uid_index IF EXISTS;

--- a/db/neo4j/migrations/20260511120000_add_catalogue_category_property_uid_index.up.cypher
+++ b/db/neo4j/migrations/20260511120000_add_catalogue_category_property_uid_index.up.cypher
@@ -1,0 +1,1 @@
+CREATE INDEX CatalogueCategoryProperty_uid_index IF NOT EXISTS FOR (p:CatalogueCategoryProperty) ON (p.uid);

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -213,7 +213,7 @@ type sortPropertyTypeRow struct {
 	Code string `json:"code"`
 }
 
-func ResolveSortPropertyTypesQuery(uids []string) helpers.DatabaseQuery {
+func resolveSortPropertyTypesQuery(uids []string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
 		Query: `
 			MATCH (p:CatalogueCategoryProperty)
@@ -237,6 +237,25 @@ var catalogueItemSortWhitelist = map[string]string{
 	"lastUpdateBy":    "lastUpdateUser",
 }
 
+func collectCustomPropertySortUids(sorting *[]helpers.Sorting) []string {
+	if sorting == nil {
+		return nil
+	}
+	var uids []string
+	for _, s := range *sorting {
+		if _, ok := catalogueItemSortWhitelist[s.ID]; ok {
+			continue
+		}
+		if _, err := uuid.Parse(s.ID); err == nil {
+			uids = append(uids, s.ID)
+		}
+	}
+	return uids
+}
+
+// Items missing the sorted custom property surface at the head in DESC and tail
+// in ASC — toggling direction does not just reverse the order. This follows
+// Cypher's default NULL ordering and is intentional per design discussion.
 func buildCatalogueItemsSortClause(
 	sorting *[]helpers.Sorting,
 	propTypes sortPropertyTypes,

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -293,7 +293,7 @@ func buildCatalogueItemsSortClause(
 				paramKey := fmt.Sprintf("sortPropKey%d", i)
 
 				matchClauses = append(matchClauses, fmt.Sprintf(
-					"OPTIONAL MATCH (itm)-[%s:HAS_CATALOGUE_PROPERTY]->(%s{uid: $%s})",
+					"OPTIONAL MATCH (itm)-[%s:HAS_CATALOGUE_PROPERTY]->(%s:CatalogueCategoryProperty{uid: $%s})",
 					pvAlias, propAlias, paramKey,
 				))
 
@@ -325,7 +325,7 @@ func buildCatalogueItemsSortClause(
 			sb.WriteString(m)
 			sb.WriteString("\n")
 		}
-		sb.WriteString("WITH itm, cat, sname")
+		sb.WriteString("WITH DISTINCT itm, cat, sname")
 		for _, w := range withExprs {
 			sb.WriteString(", ")
 			sb.WriteString(w)
@@ -423,7 +423,7 @@ func CatalogueItemsFiltersPaginationQuery(search string, categoryUid string, ski
 			},
 			propertyGroup: groupName,
 			value: value
-		}) ELSE NULL END
+		}) ELSE [] END
 	} AS items
 	`
 

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -216,7 +216,7 @@ type sortPropertyTypeRow struct {
 func ResolveSortPropertyTypesQuery(uids []string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
 		Query: `
-			MATCH (p:CatalogueProperty)
+			MATCH (p:CatalogueCategoryProperty)
 			WHERE p.uid IN $uids
 			OPTIONAL MATCH (p)-[:IS_PROPERTY_TYPE]->(t)
 			RETURN { uid: p.uid, code: coalesce(t.code, '') } AS row`,

--- a/services/catalogue-service/catalogue-db-queries.go
+++ b/services/catalogue-service/catalogue-db-queries.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 )
 
 func CatalogueItemsFiltersPrepareQuery(search string, categoryUid string, filering *[]helpers.ColumnFilter, skip, limit int) (result helpers.DatabaseQuery) {
@@ -205,8 +206,126 @@ func buildCatalogueItemsFilterConditions(filering *[]helpers.ColumnFilter) (filt
 	return filterConditions, parameters
 }
 
+type sortPropertyTypes map[string]string
+
+type sortPropertyTypeRow struct {
+	Uid  string `json:"uid"`
+	Code string `json:"code"`
+}
+
+func ResolveSortPropertyTypesQuery(uids []string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `
+			MATCH (p:CatalogueProperty)
+			WHERE p.uid IN $uids
+			OPTIONAL MATCH (p)-[:IS_PROPERTY_TYPE]->(t)
+			RETURN { uid: p.uid, code: coalesce(t.code, '') } AS row`,
+		Parameters:  map[string]interface{}{"uids": uids},
+		ReturnAlias: "row",
+	}
+}
+
+var catalogueItemSortWhitelist = map[string]string{
+	"name":            "itm.name",
+	"catalogueNumber": "itm.catalogueNumber",
+	"partNumber":      "itm.catalogueNumber",
+	"categoryName":    "cat.name",
+	"description":     "itm.description",
+	"manufacturerUrl": "itm.manufacturerUrl",
+	"supplier":        "sname",
+	"lastUpdateTime":  "lastUpdateTime",
+	"lastUpdateBy":    "lastUpdateUser",
+}
+
+func buildCatalogueItemsSortClause(
+	sorting *[]helpers.Sorting,
+	propTypes sortPropertyTypes,
+) (optionalMatchSQL string, extraReturnVars []string, orderByClause string, params map[string]interface{}) {
+
+	params = make(map[string]interface{})
+
+	var (
+		matchClauses []string
+		withExprs    []string
+		orderByParts []string
+	)
+
+	if sorting != nil {
+		for _, entry := range *sorting {
+			id := entry.ID
+			direction := helpers.GetSortingDirectionString(entry.DESC)
+
+			if expr, ok := catalogueItemSortWhitelist[id]; ok {
+				orderByParts = append(orderByParts, fmt.Sprintf("%s %s", expr, direction))
+				continue
+			}
+
+			if _, parseErr := uuid.Parse(id); parseErr == nil {
+				code, known := propTypes[id]
+				if !known {
+					log.Warn().Str("sortId", id).Msg("catalogue items sort: property uid not found, skipping")
+					continue
+				}
+
+				i := len(matchClauses)
+				pvAlias := fmt.Sprintf("pvSort%d", i)
+				propAlias := fmt.Sprintf("propSort%d", i)
+				sortValueAlias := fmt.Sprintf("sortValue%d", i)
+				paramKey := fmt.Sprintf("sortPropKey%d", i)
+
+				matchClauses = append(matchClauses, fmt.Sprintf(
+					"OPTIONAL MATCH (itm)-[%s:HAS_CATALOGUE_PROPERTY]->(%s{uid: $%s})",
+					pvAlias, propAlias, paramKey,
+				))
+
+				var valueExpr string
+				switch code {
+				case "number":
+					valueExpr = fmt.Sprintf("toFloat(%s.value)", pvAlias)
+				case "range":
+					valueExpr = fmt.Sprintf("toFloat(apoc.convert.fromJsonMap(%s.value).min)", pvAlias)
+				default:
+					valueExpr = fmt.Sprintf("toLower(toString(%s.value))", pvAlias)
+				}
+
+				withExprs = append(withExprs, fmt.Sprintf("%s AS %s", valueExpr, sortValueAlias))
+				extraReturnVars = append(extraReturnVars, sortValueAlias)
+				orderByParts = append(orderByParts, fmt.Sprintf("%s %s", sortValueAlias, direction))
+				params[paramKey] = id
+				continue
+			}
+
+			log.Warn().Str("sortId", id).Msg("catalogue items sort: unknown id, skipping")
+		}
+	}
+
+	if len(matchClauses) > 0 {
+		var sb strings.Builder
+		sb.WriteString("\n")
+		for _, m := range matchClauses {
+			sb.WriteString(m)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("WITH itm, cat, sname")
+		for _, w := range withExprs {
+			sb.WriteString(", ")
+			sb.WriteString(w)
+		}
+		sb.WriteString("\n")
+		optionalMatchSQL = sb.String()
+	}
+
+	if len(orderByParts) == 0 {
+		orderByParts = append(orderByParts, "lastUpdateTime DESC")
+	}
+	orderByParts = append(orderByParts, "itm.uid ASC")
+
+	orderByClause = " ORDER BY " + strings.Join(orderByParts, ", ") + " "
+	return
+}
+
 // Get catalogue items with pagination and filters
-func CatalogueItemsFiltersPaginationQuery(search string, categoryUid string, skip int, limit int, filering *[]helpers.ColumnFilter, sorting *[]helpers.Sorting) (result helpers.DatabaseQuery) {
+func CatalogueItemsFiltersPaginationQuery(search string, categoryUid string, skip int, limit int, filering *[]helpers.ColumnFilter, sorting *[]helpers.Sorting, propTypes sortPropertyTypes) (result helpers.DatabaseQuery) {
 
 	result = CatalogueItemsFiltersPrepareQuery(search, categoryUid, filering, skip, limit)
 
@@ -220,7 +339,13 @@ func CatalogueItemsFiltersPaginationQuery(search string, categoryUid string, ski
 		result.Query += " AND (" + strings.Join(filterConditions, " AND ") + ")"
 	}
 
-	// Add latest update subquery and pagination
+	sortMatchSQL, sortReturnVars, orderByClause, sortParams := buildCatalogueItemsSortClause(sorting, propTypes)
+	for k, v := range sortParams {
+		result.Parameters[k] = v
+	}
+
+	result.Query += sortMatchSQL
+
 	result.Query += `
 
 		// Latest update per item via ordered subquery
@@ -233,35 +358,13 @@ func CatalogueItemsFiltersPaginationQuery(search string, categoryUid string, ski
 		}
 
 		// Page on the reduced set
-		RETURN itm, cat, lastUpdateTime, lastUpdateUser`
+		RETURN itm, cat, lastUpdateTime, lastUpdateUser, sname`
 
-	// Add sorting
-	if sorting != nil && len(*sorting) > 0 {
-		result.Query += " ORDER BY "
-		for ids, sort := range *sorting {
-			sortName := sort.ID
-			// handle special cases
-			if sortName == "partNumber" {
-				sortName = "itm.catalogueNumber"
-			} else if sortName == "catalogueNumber" {
-				sortName = "itm.catalogueNumber"
-			} else if sortName == "categoryName" {
-				sortName = "cat.name"
-			} else if sortName == "name" {
-				sortName = "itm.name"
-			} else if sortName == "lastUpdateTime" {
-				sortName = "lastUpdateTime"
-			}
-
-			if ids == len(*sorting)-1 {
-				result.Query += fmt.Sprintf(" %s %s ", sortName, helpers.GetSortingDirectionString(sort.DESC))
-			} else {
-				result.Query += fmt.Sprintf(" %s %s, ", sortName, helpers.GetSortingDirectionString(sort.DESC))
-			}
-		}
-	} else {
-		result.Query += " ORDER BY lastUpdateTime DESC "
+	for _, v := range sortReturnVars {
+		result.Query += ", " + v
 	}
+
+	result.Query += orderByClause
 
 	result.Query += `
 		SKIP toInteger($skip)

--- a/services/catalogue-service/catalogue-db-queries_sort_test.go
+++ b/services/catalogue-service/catalogue-db-queries_sort_test.go
@@ -1,0 +1,250 @@
+package catalogueService
+
+import (
+	"panda/apigateway/helpers"
+	"strings"
+	"testing"
+)
+
+func TestBuildSortClause_EmptySorting(t *testing.T) {
+	opt, ret, orderBy, params := buildCatalogueItemsSortClause(nil, nil)
+	if opt != "" {
+		t.Errorf("optionalMatchSQL not empty: %q", opt)
+	}
+	if len(ret) != 0 {
+		t.Errorf("extraReturnVars not empty: %v", ret)
+	}
+	want := " ORDER BY lastUpdateTime DESC, itm.uid ASC "
+	if orderBy != want {
+		t.Errorf("orderBy = %q, want %q", orderBy, want)
+	}
+	if len(params) != 0 {
+		t.Errorf("params not empty: %v", params)
+	}
+}
+
+func TestBuildSortClause_Builtins(t *testing.T) {
+	cases := []struct {
+		id       string
+		desc     bool
+		wantExpr string
+	}{
+		{"name", false, "itm.name ASC"},
+		{"name", true, "itm.name DESC"},
+		{"catalogueNumber", false, "itm.catalogueNumber ASC"},
+		{"partNumber", false, "itm.catalogueNumber ASC"},
+		{"categoryName", true, "cat.name DESC"},
+		{"description", false, "itm.description ASC"},
+		{"manufacturerUrl", false, "itm.manufacturerUrl ASC"},
+		{"supplier", false, "sname ASC"},
+		{"lastUpdateTime", true, "lastUpdateTime DESC"},
+		{"lastUpdateBy", false, "lastUpdateUser ASC"},
+	}
+	for _, c := range cases {
+		t.Run(c.id, func(t *testing.T) {
+			opt, ret, orderBy, params := buildCatalogueItemsSortClause(
+				&[]helpers.Sorting{{ID: c.id, DESC: c.desc}}, nil)
+			if opt != "" {
+				t.Errorf("optionalMatchSQL not empty: %q", opt)
+			}
+			if len(ret) != 0 {
+				t.Errorf("extraReturnVars not empty: %v", ret)
+			}
+			want := " ORDER BY " + c.wantExpr + ", itm.uid ASC "
+			if orderBy != want {
+				t.Errorf("orderBy = %q, want %q", orderBy, want)
+			}
+			if len(params) != 0 {
+				t.Errorf("params not empty: %v", params)
+			}
+		})
+	}
+}
+
+func TestBuildSortClause_CustomProperty_Text(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{uid: "text"}
+	opt, ret, orderBy, params := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
+
+	if !strings.Contains(opt, "OPTIONAL MATCH (itm)-[pvSort0:HAS_CATALOGUE_PROPERTY]->(propSort0{uid: $sortPropKey0})") {
+		t.Errorf("missing OPTIONAL MATCH; opt=%q", opt)
+	}
+	if !strings.Contains(opt, "toLower(toString(pvSort0.value)) AS sortValue0") {
+		t.Errorf("missing text expression; opt=%q", opt)
+	}
+	if !strings.Contains(opt, "WITH itm, cat, sname,") {
+		t.Errorf("missing narrowing WITH; opt=%q", opt)
+	}
+	if len(ret) != 1 || ret[0] != "sortValue0" {
+		t.Errorf("extraReturnVars = %v", ret)
+	}
+	if orderBy != " ORDER BY sortValue0 ASC, itm.uid ASC " {
+		t.Errorf("orderBy = %q", orderBy)
+	}
+	if params["sortPropKey0"] != uid {
+		t.Errorf("params[sortPropKey0] = %v, want %v", params["sortPropKey0"], uid)
+	}
+}
+
+func TestBuildSortClause_CustomProperty_Number(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{uid: "number"}
+	opt, _, orderBy, _ := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: uid, DESC: true}}, propTypes)
+
+	if !strings.Contains(opt, "toFloat(pvSort0.value) AS sortValue0") {
+		t.Errorf("missing number expression; opt=%q", opt)
+	}
+	if orderBy != " ORDER BY sortValue0 DESC, itm.uid ASC " {
+		t.Errorf("orderBy = %q", orderBy)
+	}
+}
+
+func TestBuildSortClause_CustomProperty_Range(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{uid: "range"}
+	opt, _, _, _ := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
+
+	if !strings.Contains(opt, "toFloat(apoc.convert.fromJsonMap(pvSort0.value).min) AS sortValue0") {
+		t.Errorf("missing range expression; opt=%q", opt)
+	}
+}
+
+func TestBuildSortClause_CustomProperty_List(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{uid: "list"}
+	opt, _, _, _ := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
+
+	if !strings.Contains(opt, "toLower(toString(pvSort0.value)) AS sortValue0") {
+		t.Errorf("list type should use text expression; opt=%q", opt)
+	}
+}
+
+func TestBuildSortClause_MultiColumn(t *testing.T) {
+	uid1 := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	uid2 := "2bdeae21-ab0f-40f3-868d-36f7d40210cb"
+	propTypes := sortPropertyTypes{uid1: "number", uid2: "text"}
+	opt, ret, orderBy, params := buildCatalogueItemsSortClause(&[]helpers.Sorting{
+		{ID: "name", DESC: false},
+		{ID: uid1, DESC: true},
+		{ID: uid2, DESC: false},
+	}, propTypes)
+
+	if !strings.Contains(opt, "pvSort0:HAS_CATALOGUE_PROPERTY") {
+		t.Errorf("missing pvSort0; opt=%q", opt)
+	}
+	if !strings.Contains(opt, "pvSort1:HAS_CATALOGUE_PROPERTY") {
+		t.Errorf("missing pvSort1; opt=%q", opt)
+	}
+	if !strings.Contains(opt, "toFloat(pvSort0.value) AS sortValue0") {
+		t.Errorf("missing sortValue0; opt=%q", opt)
+	}
+	if !strings.Contains(opt, "toLower(toString(pvSort1.value)) AS sortValue1") {
+		t.Errorf("missing sortValue1; opt=%q", opt)
+	}
+	if len(ret) != 2 || ret[0] != "sortValue0" || ret[1] != "sortValue1" {
+		t.Errorf("extraReturnVars = %v", ret)
+	}
+	want := " ORDER BY itm.name ASC, sortValue0 DESC, sortValue1 ASC, itm.uid ASC "
+	if orderBy != want {
+		t.Errorf("orderBy = %q, want %q", orderBy, want)
+	}
+	if params["sortPropKey0"] != uid1 || params["sortPropKey1"] != uid2 {
+		t.Errorf("params = %v", params)
+	}
+}
+
+func TestBuildSortClause_UnknownIdSkipped(t *testing.T) {
+	opt, ret, orderBy, params := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: "Inletflangesize", DESC: false}}, nil)
+
+	if opt != "" {
+		t.Errorf("optionalMatchSQL not empty: %q", opt)
+	}
+	if len(ret) != 0 {
+		t.Errorf("extraReturnVars not empty: %v", ret)
+	}
+	if strings.Contains(orderBy, "Inletflangesize") {
+		t.Errorf("unknown id leaked into orderBy: %q", orderBy)
+	}
+	if orderBy != " ORDER BY lastUpdateTime DESC, itm.uid ASC " {
+		t.Errorf("orderBy = %q", orderBy)
+	}
+	if len(params) != 0 {
+		t.Errorf("params not empty: %v", params)
+	}
+}
+
+func TestBuildSortClause_UnknownPropertyUidSkipped(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{}
+	opt, _, orderBy, params := buildCatalogueItemsSortClause(
+		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
+
+	if opt != "" {
+		t.Errorf("optionalMatchSQL not empty: %q", opt)
+	}
+	if orderBy != " ORDER BY lastUpdateTime DESC, itm.uid ASC " {
+		t.Errorf("orderBy = %q", orderBy)
+	}
+	if len(params) != 0 {
+		t.Errorf("params not empty: %v", params)
+	}
+}
+
+func TestBuildSortClause_InjectionAttempt(t *testing.T) {
+	cases := []string{
+		"itm.name) RETURN 1 //",
+		"x; DROP DATABASE neo4j",
+		"sname DESC, itm.uid ASC) UNION MATCH (n) RETURN n",
+	}
+	for _, id := range cases {
+		opt, _, orderBy, params := buildCatalogueItemsSortClause(
+			&[]helpers.Sorting{{ID: id, DESC: false}}, nil)
+		if strings.Contains(opt, id) || strings.Contains(orderBy, id) {
+			t.Errorf("injection leaked for %q; opt=%q orderBy=%q", id, opt, orderBy)
+		}
+		if len(params) != 0 {
+			t.Errorf("params not empty for %q: %v", id, params)
+		}
+	}
+}
+
+func TestPaginationQuery_AlwaysHasTiebreaker(t *testing.T) {
+	q := CatalogueItemsFiltersPaginationQuery("", "", 0, 50, nil, nil, nil)
+	if !strings.Contains(q.Query, "ORDER BY lastUpdateTime DESC, itm.uid ASC") {
+		t.Errorf("missing tiebreaker on default sort; query=%q", q.Query)
+	}
+}
+
+func TestPaginationQuery_SupplierSort_ProjectsSname(t *testing.T) {
+	q := CatalogueItemsFiltersPaginationQuery("", "", 0, 50, nil,
+		&[]helpers.Sorting{{ID: "supplier", DESC: false}}, nil)
+
+	if !strings.Contains(q.Query, "RETURN itm, cat, lastUpdateTime, lastUpdateUser, sname") {
+		t.Errorf("missing sname in RETURN; query=%q", q.Query)
+	}
+	if !strings.Contains(q.Query, "ORDER BY sname ASC, itm.uid ASC") {
+		t.Errorf("missing supplier ORDER BY; query=%q", q.Query)
+	}
+}
+
+func TestPaginationQuery_CustomPropertySort_BoundParam(t *testing.T) {
+	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	propTypes := sortPropertyTypes{uid: "number"}
+	q := CatalogueItemsFiltersPaginationQuery("", "", 0, 50, nil,
+		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
+
+	if !strings.Contains(q.Query, "$sortPropKey0") {
+		t.Errorf("missing $sortPropKey0 in query; query=%q", q.Query)
+	}
+	if q.Parameters["sortPropKey0"] != uid {
+		t.Errorf("sortPropKey0 param = %v, want %v", q.Parameters["sortPropKey0"], uid)
+	}
+	if strings.Contains(q.Query, uid) {
+		t.Errorf("uid leaked into query string instead of being parameterized; query=%q", q.Query)
+	}
+}

--- a/services/catalogue-service/catalogue-db-queries_sort_test.go
+++ b/services/catalogue-service/catalogue-db-queries_sort_test.go
@@ -67,14 +67,14 @@ func TestBuildSortClause_CustomProperty_Text(t *testing.T) {
 	opt, ret, orderBy, params := buildCatalogueItemsSortClause(
 		&[]helpers.Sorting{{ID: uid, DESC: false}}, propTypes)
 
-	if !strings.Contains(opt, "OPTIONAL MATCH (itm)-[pvSort0:HAS_CATALOGUE_PROPERTY]->(propSort0{uid: $sortPropKey0})") {
+	if !strings.Contains(opt, "OPTIONAL MATCH (itm)-[pvSort0:HAS_CATALOGUE_PROPERTY]->(propSort0:CatalogueCategoryProperty{uid: $sortPropKey0})") {
 		t.Errorf("missing OPTIONAL MATCH; opt=%q", opt)
 	}
 	if !strings.Contains(opt, "toLower(toString(pvSort0.value)) AS sortValue0") {
 		t.Errorf("missing text expression; opt=%q", opt)
 	}
-	if !strings.Contains(opt, "WITH itm, cat, sname,") {
-		t.Errorf("missing narrowing WITH; opt=%q", opt)
+	if !strings.Contains(opt, "WITH DISTINCT itm, cat, sname,") {
+		t.Errorf("missing narrowing WITH DISTINCT; opt=%q", opt)
 	}
 	if len(ret) != 1 || ret[0] != "sortValue0" {
 		t.Errorf("extraReturnVars = %v", ret)

--- a/services/catalogue-service/catalogue-db-queries_sort_test.go
+++ b/services/catalogue-service/catalogue-db-queries_sort_test.go
@@ -232,6 +232,47 @@ func TestPaginationQuery_SupplierSort_ProjectsSname(t *testing.T) {
 	}
 }
 
+func TestCollectCustomPropertySortUids(t *testing.T) {
+	uid1 := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
+	uid2 := "2bdeae21-ab0f-40f3-868d-36f7d40210cb"
+
+	cases := []struct {
+		name    string
+		sorting *[]helpers.Sorting
+		want    []string
+	}{
+		{"nil sorting", nil, nil},
+		{"empty sorting", &[]helpers.Sorting{}, nil},
+		{"only builtins skipped", &[]helpers.Sorting{
+			{ID: "name"}, {ID: "supplier"}, {ID: "lastUpdateTime"},
+		}, nil},
+		{"only garbage skipped", &[]helpers.Sorting{
+			{ID: "Inletflangesize"}, {ID: "x; DROP DATABASE neo4j"},
+		}, nil},
+		{"single uuid kept", &[]helpers.Sorting{{ID: uid1}}, []string{uid1}},
+		{"mixed builtin + uuid + garbage", &[]helpers.Sorting{
+			{ID: "name"}, {ID: uid1}, {ID: "Inletflangesize"}, {ID: uid2},
+		}, []string{uid1, uid2}},
+		{"preserves order", &[]helpers.Sorting{
+			{ID: uid2}, {ID: "supplier"}, {ID: uid1},
+		}, []string{uid2, uid1}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := collectCustomPropertySortUids(c.sorting)
+			if len(got) != len(c.want) {
+				t.Fatalf("len=%d want=%d (got=%v want=%v)", len(got), len(c.want), got, c.want)
+			}
+			for i := range got {
+				if got[i] != c.want[i] {
+					t.Errorf("idx %d: got %q want %q", i, got[i], c.want[i])
+				}
+			}
+		})
+	}
+}
+
 func TestPaginationQuery_CustomPropertySort_BoundParam(t *testing.T) {
 	uid := "1adeae21-ab0f-40f3-868d-36f7d40210ca"
 	propTypes := sortPropertyTypes{uid: "number"}

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -85,12 +85,47 @@ func (svc *CatalogueService) GetCatalogueCategoriesRecursiveByParentUID(parentUI
 	return categories, err
 }
 
+func (svc *CatalogueService) resolveSortPropertyTypes(session neo4j.Session, sorting *[]helpers.Sorting) (sortPropertyTypes, error) {
+	if sorting == nil || len(*sorting) == 0 {
+		return sortPropertyTypes{}, nil
+	}
+
+	var uids []string
+	for _, s := range *sorting {
+		if _, ok := catalogueItemSortWhitelist[s.ID]; ok {
+			continue
+		}
+		if _, err := uuid.Parse(s.ID); err == nil {
+			uids = append(uids, s.ID)
+		}
+	}
+
+	if len(uids) == 0 {
+		return sortPropertyTypes{}, nil
+	}
+
+	rows, err := helpers.GetNeo4jArrayOfNodes[sortPropertyTypeRow](session, ResolveSortPropertyTypesQuery(uids))
+	if err != nil {
+		return nil, err
+	}
+
+	result := make(sortPropertyTypes, len(rows))
+	for _, r := range rows {
+		result[r.Uid] = r.Code
+	}
+	return result, nil
+}
+
 func (svc *CatalogueService) GetCatalogueItems(search string, categoryUid string, pageSize int, page int, filering *[]helpers.ColumnFilter, sorting *[]helpers.Sorting) (result helpers.PaginationResult[models.CatalogueItemSimple], err error) {
 
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 
-	//get all categories by parent path
-	query := CatalogueItemsFiltersPaginationQuery(search, categoryUid, pageSize*(page-1), pageSize, filering, sorting)
+	propTypes, err := svc.resolveSortPropertyTypes(session, sorting)
+	if err != nil {
+		return result, err
+	}
+
+	query := CatalogueItemsFiltersPaginationQuery(search, categoryUid, pageSize*(page-1), pageSize, filering, sorting, propTypes)
 
 	items, err := helpers.GetNeo4jArrayOfNodes[models.CatalogueItemSimple](session, query)
 	totalCount, _ := helpers.GetNeo4jSingleRecordSingleValue[int64](session, CatalogueItemsFiltersTotalCountQuery(search, categoryUid, filering))

--- a/services/catalogue-service/catalogue-service.go
+++ b/services/catalogue-service/catalogue-service.go
@@ -86,25 +86,12 @@ func (svc *CatalogueService) GetCatalogueCategoriesRecursiveByParentUID(parentUI
 }
 
 func (svc *CatalogueService) resolveSortPropertyTypes(session neo4j.Session, sorting *[]helpers.Sorting) (sortPropertyTypes, error) {
-	if sorting == nil || len(*sorting) == 0 {
-		return sortPropertyTypes{}, nil
-	}
-
-	var uids []string
-	for _, s := range *sorting {
-		if _, ok := catalogueItemSortWhitelist[s.ID]; ok {
-			continue
-		}
-		if _, err := uuid.Parse(s.ID); err == nil {
-			uids = append(uids, s.ID)
-		}
-	}
-
+	uids := collectCustomPropertySortUids(sorting)
 	if len(uids) == 0 {
 		return sortPropertyTypes{}, nil
 	}
 
-	rows, err := helpers.GetNeo4jArrayOfNodes[sortPropertyTypeRow](session, ResolveSortPropertyTypesQuery(uids))
+	rows, err := helpers.GetNeo4jArrayOfNodes[sortPropertyTypeRow](session, resolveSortPropertyTypesQuery(uids))
 	if err != nil {
 		return nil, err
 	}

--- a/services/catalogue-service/models/model_catalogue_item.go
+++ b/services/catalogue-service/models/model_catalogue_item.go
@@ -56,7 +56,7 @@ type CatalogueItemSimple struct {
 
 	ManufacturerUrl string `json:"manufacturerUrl,omitempty"`
 
-	Details []CatalogueItemDetail `json:"details,omitempty"`
+	Details []CatalogueItemDetail `json:"details"`
 
 	MiniImageUrl *[]string `json:"miniImageUrl" neo4j:"ignore"`
 


### PR DESCRIPTION
Closes #415

## Summary
- Replace the else-if ladder in `CatalogueItemsFiltersPaginationQuery` with a strict whitelist of sortable built-in columns + a UUID-driven path for custom catalogue properties.
- Pre-flight property type resolution (one indexed lookup per request that uses a custom-property sort) so the main query's ORDER BY uses a single concrete type per column (`toFloat` for `number`, `toFloat(apoc.convert.fromJsonMap(...).min)` for `range`, `toLower(toString(...))` otherwise).
- Thread `sname` through the inner CALL's RETURN so `supplier` becomes sortable without re-MATCHing post-pagination.
- Append `itm.uid ASC` as final ORDER BY tiebreaker — stable pagination over duplicate sort keys.
- Closes Cypher injection: only whitelisted literals or UUID-shaped strings reach the query; everything else logs a warn and falls back to default sort.

## Behavior
- `sorting=[{"id":"supplier","desc":false}]` → 200, supplier order (was 500).
- `sorting=[{"id":"<property-uid>","desc":true}]` → 200, type-aware order (was 500).
- `sorting=[{"id":"Inletflangesize"}]` (old FE) → 200 with default sort + warn log (was 500).
- `sorting=[{"id":"itm.name) RETURN 1 //"}]` → 200 with default sort + warn log (was 500 / injection vector).

## FE companion
Frontend column id for custom property columns must switch from stripped name to property UID. Tracked in eli-eric/ELI-panda#1082. BE-first deploy is safe — old FE clients get default sort + warn instead of 500s.

## Test plan
- [x] `go test ./services/catalogue-service/... -run TestBuildSortClause` — 13 unit tests green
- [x] `go test ./services/catalogue-service/... -run TestPaginationQuery` — query-shape integration green
- [x] `go build ./...` clean, `gofmt -l` clean
- [x] Manual: hit `GET /v1/catalogue/items?sorting=...` for supplier / number-property / range-property / unknown / injection cases against a live Neo4j stack
- [x] Pagination consistency: low pageSize, walk pages on a duplicate-key sort (supplier), no missing or repeated items