### PR TITLE
feat(teams): teams module with CRUD + membership management

### DIFF
--- a/db/neo4j/migrations/20260709120000_add_teams_module.down.cypher
+++ b/db/neo4j/migrations/20260709120000_add_teams_module.down.cypher
@@ -1,0 +1,4 @@
+DROP INDEX Team_name_index IF EXISTS;
+DROP CONSTRAINT Team_uid_unique IF EXISTS;
+MATCH (r:Role{code:'teams-view'}) DETACH DELETE r;
+MATCH (r:Role{code:'teams-edit'}) DETACH DELETE r;

--- a/db/neo4j/migrations/20260709120000_add_teams_module.up.cypher
+++ b/db/neo4j/migrations/20260709120000_add_teams_module.up.cypher
@@ -1,0 +1,4 @@
+MERGE (r:Role{ name: 'Teams View', code: 'teams-view' }) ON CREATE SET r.uid = apoc.create.uuid();
+MERGE (r:Role{ name: 'Teams Edit', code: 'teams-edit' }) ON CREATE SET r.uid = apoc.create.uuid();
+CREATE CONSTRAINT Team_uid_unique IF NOT EXISTS FOR (t:Team) REQUIRE t.uid IS UNIQUE;
+CREATE INDEX Team_name_index IF NOT EXISTS FOR (t:Team) ON (t.name);

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6258,6 +6258,416 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/teams": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all teams for the current facility (flat list with member counts)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get all teams",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TeamListItem"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new team (name required; code optional but unique per facility)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Create team",
+                "parameters": [
+                    {
+                        "description": "Team",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a team with its full member list",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get team by uid",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Full replace of team name/code/description",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Update team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Team",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Hard delete a team. Rejected with 409 if Systems or Room Cards still reference it.",
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Delete team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "description": "Conflict"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partial update of team params (absent key = unchanged; explicit null = clear)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Patch team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Partial team fields",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}/members": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replace the entire member set of a team with the supplied user uids (add + remove diff).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Replace team members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User uids",
+                        "name": "members",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamMembersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Add one or more users to a team (idempotent). All uids must be users in the facility.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Add team members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User uids",
+                        "name": "members",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamMembersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}/members/{userUid}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a single user from a team. Idempotent (200 even if the user was not a member).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Remove a team member",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "user uid",
+                        "name": "userUid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/users/{userUID}/disable": {
             "post": {
                 "security": [
@@ -8956,6 +9366,128 @@ const docTemplate = `{
                     }
                 },
                 "targetParentSystemUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Team": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamCreateRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamDetail": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.TeamMember"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamListItem": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "memberCount": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamMember": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "isEnabled": {
+                    "type": "boolean"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamMembersRequest": {
+            "type": "object",
+            "properties": {
+                "userUids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "models.TeamUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6255,6 +6255,416 @@
                 }
             }
         },
+        "/v1/teams": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get all teams for the current facility (flat list with member counts)",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get all teams",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TeamListItem"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Create a new team (name required; code optional but unique per facility)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Create team",
+                "parameters": [
+                    {
+                        "description": "Team",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamCreateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get a team with its full member list",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get team by uid",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Full replace of team name/code/description",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Update team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Team",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamUpdateRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Hard delete a team. Rejected with 409 if Systems or Room Cards still reference it.",
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Delete team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "409": {
+                        "description": "Conflict"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "patch": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Partial update of team params (absent key = unchanged; explicit null = clear)",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Patch team",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Partial team fields",
+                        "name": "team",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.Team"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}/members": {
+            "put": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Replace the entire member set of a team with the supplied user uids (add + remove diff).",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Replace team members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User uids",
+                        "name": "members",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamMembersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            },
+            "post": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Add one or more users to a team (idempotent). All uids must be users in the facility.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Add team members",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "User uids",
+                        "name": "members",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamMembersRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request"
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
+        "/v1/teams/{uid}/members/{userUid}": {
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Remove a single user from a team. Idempotent (200 even if the user was not a member).",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Remove a team member",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "team uid",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "user uid",
+                        "name": "userUid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.TeamDetail"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found"
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/users/{userUID}/disable": {
             "post": {
                 "security": [
@@ -8953,6 +9363,128 @@
                     }
                 },
                 "targetParentSystemUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.Team": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamCreateRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamDetail": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "members": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.TeamMember"
+                    }
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamListItem": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "memberCount": {
+                    "type": "integer"
+                },
+                "name": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamMember": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "isEnabled": {
+                    "type": "boolean"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.TeamMembersRequest": {
+            "type": "object",
+            "properties": {
+                "userUids": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "models.TeamUpdateRequest": {
+            "type": "object",
+            "properties": {
+                "code": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "name": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1558,6 +1558,85 @@ definitions:
       targetParentSystemUid:
         type: string
     type: object
+  models.Team:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamCreateRequest:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    type: object
+  models.TeamDetail:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      members:
+        items:
+          $ref: '#/definitions/models.TeamMember'
+        type: array
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamListItem:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      memberCount:
+        type: integer
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamMember:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      isEnabled:
+        type: boolean
+      lastName:
+        type: string
+      uid:
+        type: string
+      username:
+        type: string
+    type: object
+  models.TeamMembersRequest:
+    properties:
+      userUids:
+        items:
+          type: string
+        type: array
+    type: object
+  models.TeamUpdateRequest:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    type: object
   models.UserAuthInfo:
     properties:
       accessToken:
@@ -5808,6 +5887,272 @@ paths:
       summary: Get all zones
       tags:
       - Systems
+  /v1/teams:
+    get:
+      description: Get all teams for the current facility (flat list with member counts)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TeamListItem'
+            type: array
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get all teams
+      tags:
+      - Teams
+    post:
+      consumes:
+      - application/json
+      description: Create a new team (name required; code optional but unique per
+        facility)
+      parameters:
+      - description: Team
+        in: body
+        name: team
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Create team
+      tags:
+      - Teams
+  /v1/teams/{uid}:
+    delete:
+      description: Hard delete a team. Rejected with 409 if Systems or Room Cards
+        still reference it.
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not Found
+        "409":
+          description: Conflict
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Delete team
+      tags:
+      - Teams
+    get:
+      description: Get a team with its full member list
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get team by uid
+      tags:
+      - Teams
+    patch:
+      consumes:
+      - application/json
+      description: Partial update of team params (absent key = unchanged; explicit
+        null = clear)
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Partial team fields
+        in: body
+        name: team
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Patch team
+      tags:
+      - Teams
+    put:
+      consumes:
+      - application/json
+      description: Full replace of team name/code/description
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Team
+        in: body
+        name: team
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Update team
+      tags:
+      - Teams
+  /v1/teams/{uid}/members:
+    post:
+      consumes:
+      - application/json
+      description: Add one or more users to a team (idempotent). All uids must be
+        users in the facility.
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: User uids
+        in: body
+        name: members
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamMembersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Add team members
+      tags:
+      - Teams
+    put:
+      consumes:
+      - application/json
+      description: Replace the entire member set of a team with the supplied user
+        uids (add + remove diff).
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: User uids
+        in: body
+        name: members
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamMembersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Replace team members
+      tags:
+      - Teams
+  /v1/teams/{uid}/members/{userUid}:
+    delete:
+      description: Remove a single user from a team. Idempotent (200 even if the user
+        was not a member).
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: user uid
+        in: path
+        name: userUid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Remove a team member
+      tags:
+      - Teams
   /v1/users/{userUID}/disable:
     post:
       description: Disables user account and invalidates auth status cache.

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -1558,6 +1558,85 @@ definitions:
       targetParentSystemUid:
         type: string
     type: object
+  models.Team:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamCreateRequest:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    type: object
+  models.TeamDetail:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      members:
+        items:
+          $ref: '#/definitions/models.TeamMember'
+        type: array
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamListItem:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      memberCount:
+        type: integer
+      name:
+        type: string
+      uid:
+        type: string
+    type: object
+  models.TeamMember:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      isEnabled:
+        type: boolean
+      lastName:
+        type: string
+      uid:
+        type: string
+      username:
+        type: string
+    type: object
+  models.TeamMembersRequest:
+    properties:
+      userUids:
+        items:
+          type: string
+        type: array
+    type: object
+  models.TeamUpdateRequest:
+    properties:
+      code:
+        type: string
+      description:
+        type: string
+      name:
+        type: string
+    type: object
   models.UserAuthInfo:
     properties:
       accessToken:
@@ -5808,6 +5887,272 @@ paths:
       summary: Get all zones
       tags:
       - Systems
+  /v1/teams:
+    get:
+      description: Get all teams for the current facility (flat list with member counts)
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TeamListItem'
+            type: array
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get all teams
+      tags:
+      - Teams
+    post:
+      consumes:
+      - application/json
+      description: Create a new team (name required; code optional but unique per
+        facility)
+      parameters:
+      - description: Team
+        in: body
+        name: team
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamCreateRequest'
+      produces:
+      - application/json
+      responses:
+        "201":
+          description: Created
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Create team
+      tags:
+      - Teams
+  /v1/teams/{uid}:
+    delete:
+      description: Hard delete a team. Rejected with 409 if Systems or Room Cards
+        still reference it.
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      responses:
+        "200":
+          description: OK
+        "404":
+          description: Not Found
+        "409":
+          description: Conflict
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Delete team
+      tags:
+      - Teams
+    get:
+      description: Get a team with its full member list
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get team by uid
+      tags:
+      - Teams
+    patch:
+      consumes:
+      - application/json
+      description: Partial update of team params (absent key = unchanged; explicit
+        null = clear)
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Partial team fields
+        in: body
+        name: team
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Patch team
+      tags:
+      - Teams
+    put:
+      consumes:
+      - application/json
+      description: Full replace of team name/code/description
+      parameters:
+      - description: uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: Team
+        in: body
+        name: team
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamUpdateRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.Team'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Update team
+      tags:
+      - Teams
+  /v1/teams/{uid}/members:
+    post:
+      consumes:
+      - application/json
+      description: Add one or more users to a team (idempotent). All uids must be
+        users in the facility.
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: User uids
+        in: body
+        name: members
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamMembersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Add team members
+      tags:
+      - Teams
+    put:
+      consumes:
+      - application/json
+      description: Replace the entire member set of a team with the supplied user
+        uids (add + remove diff).
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: User uids
+        in: body
+        name: members
+        required: true
+        schema:
+          $ref: '#/definitions/models.TeamMembersRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "400":
+          description: Bad Request
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Replace team members
+      tags:
+      - Teams
+  /v1/teams/{uid}/members/{userUid}:
+    delete:
+      description: Remove a single user from a team. Idempotent (200 even if the user
+        was not a member).
+      parameters:
+      - description: team uid
+        in: path
+        name: uid
+        required: true
+        type: string
+      - description: user uid
+        in: path
+        name: userUid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.TeamDetail'
+        "404":
+          description: Not Found
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Remove a team member
+      tags:
+      - Teams
   /v1/users/{userUID}/disable:
     post:
       description: Disables user account and invalidates auth status cache.

--- a/services/init.go
+++ b/services/init.go
@@ -13,6 +13,7 @@ import (
 	roomcardsservice "panda/apigateway/services/room-cards-service"
 	securityService "panda/apigateway/services/security-service"
 	systemsService "panda/apigateway/services/systems-service"
+	teamsservice "panda/apigateway/services/teams-service"
 	zoneservice "panda/apigateway/services/zone-service"
 
 	"github.com/rs/zerolog/log"
@@ -86,4 +87,10 @@ func InitializeServicesAndMapRoutes(e *echo.Echo, settings *config.Config, neo4j
 	zoneHandlers := zoneservice.NewZoneHandlers(zoneSvc)
 	zoneservice.MapZoneRoutes(e, zoneHandlers, jwtMiddleware)
 	log.Info().Msg("Zone     service initialized successfully.")
+
+	// teams service
+	teamsSvc := teamsservice.NewTeamsService(neo4jDriver)
+	teamsHandlers := teamsservice.NewTeamsHandlers(teamsSvc)
+	teamsservice.MapTeamsRoutes(e, teamsHandlers, jwtMiddleware)
+	log.Info().Msg("Teams    service initialized successfully.")
 }

--- a/services/teams-service/models/teams-models.go
+++ b/services/teams-service/models/teams-models.go
@@ -1,0 +1,73 @@
+package models
+
+// Team is the core team node projection (name/code/description), facility-scoped.
+type Team struct {
+	UID         string `json:"uid" neo4j:"key,uid"`
+	Name        string `json:"name" neo4j:"prop,name"`
+	Code        string `json:"code" neo4j:"prop,code"`
+	Description string `json:"description" neo4j:"prop,description"`
+}
+
+// TeamListItem is a team plus its member count, returned in the flat list endpoint.
+type TeamListItem struct {
+	UID         string `json:"uid"`
+	Name        string `json:"name"`
+	Code        string `json:"code"`
+	Description string `json:"description"`
+	MemberCount int    `json:"memberCount"`
+}
+
+// TeamMember is a user summary as returned in a team's member list. Disabled users
+// are included (membership persists) and flagged via IsEnabled.
+type TeamMember struct {
+	UID       string `json:"uid"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+	IsEnabled bool   `json:"isEnabled"`
+}
+
+// TeamDetail is a team plus its full inline member list.
+type TeamDetail struct {
+	UID         string       `json:"uid"`
+	Name        string       `json:"name"`
+	Code        string       `json:"code"`
+	Description string       `json:"description"`
+	Members     []TeamMember `json:"members"`
+}
+
+// TeamCreateRequest is the POST body. Name is required; code/description optional.
+type TeamCreateRequest struct {
+	Name        string `json:"name"`
+	Code        string `json:"code"`
+	Description string `json:"description"`
+}
+
+// TeamUpdateRequest is the PUT (full replace) body. Name is required; code/description
+// are overwritten (description may be null to clear).
+type TeamUpdateRequest struct {
+	Name        string  `json:"name"`
+	Code        string  `json:"code"`
+	Description *string `json:"description,omitempty"`
+}
+
+// Optional signals presence of a field in a PATCH payload. A nil *Optional pointer
+// means the JSON key was absent; a non-nil pointer with Value == nil means the key was
+// explicitly null (clear operation).
+type Optional[T any] struct {
+	Value *T
+}
+
+// PatchTeamFields is the parsed PATCH body. Name uses a plain pointer (nil = absent);
+// nullable fields use *Optional[T] (nil = absent; non-nil with Value=nil = explicit null clear).
+type PatchTeamFields struct {
+	Name        *string
+	Code        *Optional[string]
+	Description *Optional[string]
+}
+
+// TeamMembersRequest is the body for add-members (POST) and replace-members (PUT).
+type TeamMembersRequest struct {
+	UserUids []string `json:"userUids"`
+}

--- a/services/teams-service/teams-db-queries.go
+++ b/services/teams-service/teams-db-queries.go
@@ -9,8 +9,8 @@ import (
 // GetAllTeamsQuery returns every team in the facility with its member count, sorted by name.
 func GetAllTeamsQuery(facilityCode string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
-		Query: `MATCH (t:Team)-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
-				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)
+		Query: `MATCH (t:Team)-[:BELONGS_TO_FACILITY]->(f:Facility{code:$facilityCode})
+				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)-[:BELONGS_TO_FACILITY]->(f)
 				WITH t, count(u) AS memberCount
 				RETURN {uid: t.uid, name: t.name, code: coalesce(t.code, ''),
 						description: coalesce(t.description, ''), memberCount: memberCount} AS team
@@ -26,8 +26,8 @@ func GetAllTeamsQuery(facilityCode string) helpers.DatabaseQuery {
 // (including disabled users, sorted by lastName then firstName).
 func GetTeamByUIDQuery(uid, facilityCode string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
-		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
-				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)
+		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(f:Facility{code:$facilityCode})
+				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)-[:BELONGS_TO_FACILITY]->(f)
 				WITH t, u ORDER BY u.lastName, u.firstName
 				WITH t, collect(CASE WHEN u IS NULL THEN null ELSE {
 						uid: u.uid, firstName: coalesce(u.firstName, ''), lastName: coalesce(u.lastName, ''),

--- a/services/teams-service/teams-db-queries.go
+++ b/services/teams-service/teams-db-queries.go
@@ -1,0 +1,253 @@
+package teamsservice
+
+import (
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/teams-service/models"
+	"strings"
+)
+
+// GetAllTeamsQuery returns every team in the facility with its member count, sorted by name.
+func GetAllTeamsQuery(facilityCode string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team)-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)
+				WITH t, count(u) AS memberCount
+				RETURN {uid: t.uid, name: t.name, code: coalesce(t.code, ''),
+						description: coalesce(t.description, ''), memberCount: memberCount} AS team
+				ORDER BY team.name`,
+		ReturnAlias: "team",
+		Parameters: map[string]interface{}{
+			"facilityCode": facilityCode,
+		},
+	}
+}
+
+// GetTeamByUIDQuery returns a facility-scoped team with its full inline member list
+// (including disabled users, sorted by lastName then firstName).
+func GetTeamByUIDQuery(uid, facilityCode string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				OPTIONAL MATCH (t)<-[:BELONGS_TO_TEAM]-(u:User)
+				WITH t, u ORDER BY u.lastName, u.firstName
+				WITH t, collect(CASE WHEN u IS NULL THEN null ELSE {
+						uid: u.uid, firstName: coalesce(u.firstName, ''), lastName: coalesce(u.lastName, ''),
+						username: coalesce(u.username, ''), email: coalesce(u.email, ''),
+						isEnabled: coalesce(u.isEnabled, false)} END) AS members
+				RETURN {uid: t.uid, name: t.name, code: coalesce(t.code, ''),
+						description: coalesce(t.description, ''),
+						members: [m IN members WHERE m IS NOT NULL]} AS team`,
+		ReturnAlias: "team",
+		Parameters: map[string]interface{}{
+			"uid":          uid,
+			"facilityCode": facilityCode,
+		},
+	}
+}
+
+// CheckTeamCodeExistsQuery counts teams (excluding excludeUID) with the given code in the
+// facility. Only invoked when code is non-empty.
+func CheckTeamCodeExistsQuery(code, facilityCode, excludeUID string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{code:$code})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				WHERE t.uid <> $excludeUID
+				RETURN count(t) AS cnt`,
+		ReturnAlias: "cnt",
+		Parameters: map[string]interface{}{
+			"code":         code,
+			"facilityCode": facilityCode,
+			"excludeUID":   excludeUID,
+		},
+	}
+}
+
+// CreateTeamQuery creates a facility-scoped team and its INSERT audit edge.
+func CreateTeamQuery(uid, name, code, description, facilityCode, userUID string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (f:Facility{code:$facilityCode})
+				MATCH (u:User{uid:$userUID})
+				CREATE (t:Team{uid:$uid, name:$name, code:$code, description:$description})-[:BELONGS_TO_FACILITY]->(f)
+				CREATE (t)-[:WAS_UPDATED_BY{at:datetime(), action:"INSERT"}]->(u)
+				RETURN {uid: t.uid, name: t.name, code: coalesce(t.code, ''),
+						description: coalesce(t.description, '')} AS team`,
+		ReturnAlias: "team",
+		Parameters: map[string]interface{}{
+			"uid":          uid,
+			"name":         name,
+			"code":         code,
+			"description":  description,
+			"facilityCode": facilityCode,
+			"userUID":      userUID,
+		},
+	}
+}
+
+// UpdateTeamQuery is the PUT full replace. description may be nil (clears the property).
+func UpdateTeamQuery(uid, name, code string, description *string, facilityCode, userUID string) helpers.DatabaseQuery {
+	q := helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				SET t.name = $name, t.code = $code, t.description = $description
+				WITH t
+				MATCH (u:User{uid:$userUID})
+				CREATE (t)-[:WAS_UPDATED_BY{at:datetime(), action:"UPDATE"}]->(u)
+				RETURN t.uid AS uid`,
+		ReturnAlias: "uid",
+		Parameters: map[string]interface{}{
+			"uid":          uid,
+			"name":         name,
+			"code":         code,
+			"description":  nil,
+			"facilityCode": facilityCode,
+			"userUID":      userUID,
+		},
+	}
+	if description != nil {
+		q.Parameters["description"] = *description
+	}
+	return q
+}
+
+// PatchTeamQuery builds a partial-update query from the parsed PATCH fields. Only supplied
+// keys are SET (absent = untouched; explicit null clears). Writes a UPDATE audit edge with
+// the change delta. Callers must ensure at least one field is present.
+func PatchTeamQuery(uid, facilityCode, userUID string, fields *models.PatchTeamFields, changesJSON string) helpers.DatabaseQuery {
+	params := map[string]interface{}{
+		"uid":          uid,
+		"facilityCode": facilityCode,
+		"userUID":      userUID,
+		"changes":      changesJSON,
+	}
+
+	setClauses := make([]string, 0, 3)
+	if fields.Name != nil {
+		params["name"] = strings.TrimSpace(*fields.Name)
+		setClauses = append(setClauses, "t.name = $name")
+	}
+	if fields.Code != nil {
+		if fields.Code.Value != nil {
+			params["code"] = strings.TrimSpace(*fields.Code.Value)
+		} else {
+			params["code"] = nil
+		}
+		setClauses = append(setClauses, "t.code = $code")
+	}
+	if fields.Description != nil {
+		if fields.Description.Value != nil {
+			params["description"] = *fields.Description.Value
+		} else {
+			params["description"] = nil
+		}
+		setClauses = append(setClauses, "t.description = $description")
+	}
+
+	query := `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode}) `
+	if len(setClauses) > 0 {
+		query += "SET " + strings.Join(setClauses, ", ") + " "
+	}
+	query += `WITH t
+			MATCH (u:User{uid:$userUID})
+			CREATE (t)-[:WAS_UPDATED_BY{at:datetime(), action:"UPDATE", changes:$changes}]->(u)
+			RETURN t.uid AS uid`
+
+	return helpers.DatabaseQuery{
+		Query:       query,
+		ReturnAlias: "uid",
+		Parameters:  params,
+	}
+}
+
+// CheckTeamReferencesQuery returns the counts of Systems (HAS_RESPONSIBLE_TEAM) and RoomCards
+// (HAS_TEAM) still referencing the team. Sequential OPTIONAL MATCH avoids cartesian inflation.
+func CheckTeamReferencesQuery(uid, facilityCode string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				OPTIONAL MATCH (t)<-[:HAS_RESPONSIBLE_TEAM]-(s:System)
+				WITH t, count(DISTINCT s) AS systemCount
+				OPTIONAL MATCH (t)<-[:HAS_TEAM]-(rc:RoomCard)
+				RETURN {systemCount: systemCount, roomCardCount: count(DISTINCT rc)} AS refs`,
+		ReturnAlias: "refs",
+		Parameters: map[string]interface{}{
+			"uid":          uid,
+			"facilityCode": facilityCode,
+		},
+	}
+}
+
+// DeleteTeamQuery hard-deletes a facility-scoped team; DETACH removes membership + audit edges.
+func DeleteTeamQuery(uid, facilityCode string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$uid})-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				DETACH DELETE t`,
+		Parameters: map[string]interface{}{
+			"uid":          uid,
+			"facilityCode": facilityCode,
+		},
+	}
+}
+
+// ValidateTeamMemberUidsQuery returns the subset of userUids that are Users in the facility.
+func ValidateTeamMemberUidsQuery(facilityCode string, userUids []string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (u:User)-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				WHERE u.uid IN $userUids
+				RETURN collect(u.uid) AS validUids`,
+		ReturnAlias: "validUids",
+		Parameters: map[string]interface{}{
+			"facilityCode": facilityCode,
+			"userUids":     userUids,
+		},
+	}
+}
+
+// GetTeamMemberUidsQuery returns the current member uids of a team (for replace-all diffing).
+func GetTeamMemberUidsQuery(teamUID string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$teamUid})<-[:BELONGS_TO_TEAM]-(u:User)
+				RETURN collect(u.uid) AS memberUids`,
+		ReturnAlias: "memberUids",
+		Parameters: map[string]interface{}{
+			"teamUid": teamUID,
+		},
+	}
+}
+
+// MergeTeamMembersQuery idempotently links same-facility users to the team.
+func MergeTeamMembersQuery(teamUID, facilityCode string, userUids []string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$teamUid})-[:BELONGS_TO_FACILITY]->(f:Facility{code:$facilityCode})
+				MATCH (u:User)-[:BELONGS_TO_FACILITY]->(f)
+				WHERE u.uid IN $userUids
+				MERGE (u)-[:BELONGS_TO_TEAM]->(t)`,
+		Parameters: map[string]interface{}{
+			"teamUid":      teamUID,
+			"facilityCode": facilityCode,
+			"userUids":     userUids,
+		},
+	}
+}
+
+// RemoveTeamMembersQuery deletes membership edges for the given user uids.
+func RemoveTeamMembersQuery(teamUID string, userUids []string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (u:User)-[r:BELONGS_TO_TEAM]->(t:Team{uid:$teamUid})
+				WHERE u.uid IN $userUids
+				DELETE r`,
+		Parameters: map[string]interface{}{
+			"teamUid":  teamUID,
+			"userUids": userUids,
+		},
+	}
+}
+
+// TeamMembershipAuditQuery writes a single UPDATE audit edge on the team with the membership delta.
+func TeamMembershipAuditQuery(teamUID, userUID, changesJSON string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (t:Team{uid:$teamUid})
+				MATCH (u:User{uid:$userUID})
+				CREATE (t)-[:WAS_UPDATED_BY{at:datetime(), action:"UPDATE", changes:$changes}]->(u)`,
+		Parameters: map[string]interface{}{
+			"teamUid": teamUID,
+			"userUID": userUID,
+			"changes": changesJSON,
+		},
+	}
+}

--- a/services/teams-service/teams-handlers.go
+++ b/services/teams-service/teams-handlers.go
@@ -1,0 +1,316 @@
+package teamsservice
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/teams-service/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+)
+
+type TeamsHandlers struct {
+	teamsService ITeamsService
+}
+
+type ITeamsHandlers interface {
+	GetAllTeams() echo.HandlerFunc
+	GetTeamByUID() echo.HandlerFunc
+	CreateTeam() echo.HandlerFunc
+	UpdateTeam() echo.HandlerFunc
+	PatchTeam() echo.HandlerFunc
+	DeleteTeam() echo.HandlerFunc
+	AddTeamMembers() echo.HandlerFunc
+	RemoveTeamMember() echo.HandlerFunc
+	ReplaceTeamMembers() echo.HandlerFunc
+}
+
+func NewTeamsHandlers(svc ITeamsService) ITeamsHandlers {
+	return &TeamsHandlers{teamsService: svc}
+}
+
+// GetAllTeams Get all teams godoc
+// @Summary Get all teams
+// @Description Get all teams for the current facility (flat list with member counts)
+// @Tags Teams
+// @Security BearerAuth
+// @Produce json
+// @Success 200 {array} models.TeamListItem
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams [get]
+func (h *TeamsHandlers) GetAllTeams() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		facilityCode := c.Get("facilityCode").(string)
+
+		teams, err := h.teamsService.GetAllTeams(facilityCode)
+		if err != nil {
+			log.Error().Err(err).Msg("Error getting teams")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, teams)
+	}
+}
+
+// GetTeamByUID Get team by uid godoc
+// @Summary Get team by uid
+// @Description Get a team with its full member list
+// @Tags Teams
+// @Security BearerAuth
+// @Produce json
+// @Param uid path string true "uid"
+// @Success 200 {object} models.TeamDetail
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid} [get]
+func (h *TeamsHandlers) GetTeamByUID() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+		facilityCode := c.Get("facilityCode").(string)
+
+		team, err := h.teamsService.GetTeamByUID(uid, facilityCode)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return echo.ErrNotFound
+			}
+			log.Error().Err(err).Msg("Error getting team")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, team)
+	}
+}
+
+// CreateTeam Create team godoc
+// @Summary Create team
+// @Description Create a new team (name required; code optional but unique per facility)
+// @Tags Teams
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param team body models.TeamCreateRequest true "Team"
+// @Success 201 {object} models.Team
+// @Failure 400 "Bad Request"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams [post]
+func (h *TeamsHandlers) CreateTeam() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		req := new(models.TeamCreateRequest)
+		if err := c.Bind(req); err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		team, err := h.teamsService.CreateTeam(facilityCode, userUID, req)
+		if err != nil {
+			if isClientError(err) {
+				return helpers.BadRequest(err.Error())
+			}
+			log.Error().Err(err).Msg("Error creating team")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusCreated, team)
+	}
+}
+
+// UpdateTeam Update team godoc
+// @Summary Update team
+// @Description Full replace of team name/code/description
+// @Tags Teams
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param uid path string true "uid"
+// @Param team body models.TeamUpdateRequest true "Team"
+// @Success 200 {object} models.Team
+// @Failure 400 "Bad Request"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid} [put]
+func (h *TeamsHandlers) UpdateTeam() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+
+		req := new(models.TeamUpdateRequest)
+		if err := c.Bind(req); err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		team, err := h.teamsService.UpdateTeam(uid, facilityCode, userUID, req)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return echo.ErrNotFound
+			}
+			if isClientError(err) {
+				return helpers.BadRequest(err.Error())
+			}
+			log.Error().Err(err).Msg("Error updating team")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, team)
+	}
+}
+
+// PatchTeam Patch team godoc
+// @Summary Patch team
+// @Description Partial update of team params (absent key = unchanged; explicit null = clear)
+// @Tags Teams
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param uid path string true "uid"
+// @Param team body object true "Partial team fields"
+// @Success 200 {object} models.Team
+// @Failure 400 "Bad Request"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid} [patch]
+func (h *TeamsHandlers) PatchTeam() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+
+		body, err := io.ReadAll(c.Request().Body)
+		if err != nil {
+			return helpers.BadRequest("cannot read request body")
+		}
+		raw := map[string]json.RawMessage{}
+		if err := json.Unmarshal(body, &raw); err != nil {
+			return helpers.BadRequest("invalid JSON body")
+		}
+		fields, err := parsePatchTeamPayload(raw)
+		if err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		team, err := h.teamsService.PatchTeam(uid, facilityCode, userUID, fields)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return echo.ErrNotFound
+			}
+			if isClientError(err) {
+				return helpers.BadRequest(err.Error())
+			}
+			log.Error().Err(err).Msg("Error patching team")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, team)
+	}
+}
+
+// DeleteTeam Delete team godoc
+// @Summary Delete team
+// @Description Hard delete a team. Rejected with 409 if Systems or Room Cards still reference it.
+// @Tags Teams
+// @Security BearerAuth
+// @Param uid path string true "uid"
+// @Success 200 "OK"
+// @Failure 404 "Not Found"
+// @Failure 409 "Conflict"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid} [delete]
+func (h *TeamsHandlers) DeleteTeam() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		err := h.teamsService.DeleteTeam(uid, facilityCode, userUID)
+		if err != nil {
+			if errors.Is(err, ErrNotFound) {
+				return echo.ErrNotFound
+			}
+			var refErr *ReferencedError
+			if errors.As(err, &refErr) {
+				return c.JSON(http.StatusConflict, helpers.ConflictErrorResponse{
+					ErrorMessage: refErr.Error(),
+					RelatedNodes: referencedRelatedNodes(refErr),
+				})
+			}
+			log.Error().Err(err).Msg("Error deleting team")
+			return echo.ErrInternalServerError
+		}
+
+		return c.NoContent(http.StatusOK)
+	}
+}
+
+// parsePatchTeamPayload maps a raw JSON key map into typed PatchTeamFields. Absent keys stay
+// nil; explicit JSON null is captured via Optional[T] with Value=nil (clear operation).
+func parsePatchTeamPayload(raw map[string]json.RawMessage) (*models.PatchTeamFields, error) {
+	fields := &models.PatchTeamFields{}
+
+	if r, ok := raw["name"]; ok {
+		var v string
+		if err := json.Unmarshal(r, &v); err != nil {
+			return nil, errors.New("invalid name")
+		}
+		fields.Name = &v
+	}
+
+	parseOpt := func(key string) (*models.Optional[string], error) {
+		r, ok := raw[key]
+		if !ok {
+			return nil, nil
+		}
+		if rawMessageIsNull(r) {
+			return &models.Optional[string]{Value: nil}, nil
+		}
+		var v string
+		if err := json.Unmarshal(r, &v); err != nil {
+			return nil, errors.New("invalid " + key)
+		}
+		return &models.Optional[string]{Value: &v}, nil
+	}
+
+	code, err := parseOpt("code")
+	if err != nil {
+		return nil, err
+	}
+	fields.Code = code
+
+	desc, err := parseOpt("description")
+	if err != nil {
+		return nil, err
+	}
+	fields.Description = desc
+
+	return fields, nil
+}
+
+func rawMessageIsNull(r json.RawMessage) bool {
+	return bytes.Equal(bytes.TrimSpace(r), []byte("null"))
+}
+
+func referencedRelatedNodes(e *ReferencedError) []helpers.RelatedNodeLabelAmount {
+	nodes := []helpers.RelatedNodeLabelAmount{}
+	if e.SystemCount > 0 {
+		nodes = append(nodes, helpers.RelatedNodeLabelAmount{Label: "System", Count: e.SystemCount})
+	}
+	if e.RoomCardCount > 0 {
+		nodes = append(nodes, helpers.RelatedNodeLabelAmount{Label: "RoomCard", Count: e.RoomCardCount})
+	}
+	return nodes
+}
+
+func isClientError(err error) bool {
+	if errors.Is(err, ErrDuplicateCode) || errors.Is(err, ErrValidation) {
+		return true
+	}
+	var invalidMembers *InvalidMembersError
+	return errors.As(err, &invalidMembers)
+}

--- a/services/teams-service/teams-handlers_test.go
+++ b/services/teams-service/teams-handlers_test.go
@@ -1,0 +1,298 @@
+package teamsservice
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"panda/apigateway/services/teams-service/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// teamsServiceMock is a hand-written ITeamsService stub; each method delegates to an
+// optional func field so individual tests control behavior and capture arguments.
+type teamsServiceMock struct {
+	getAllFn   func(facilityCode string) ([]models.TeamListItem, error)
+	getByUIDFn func(uid, facilityCode string) (models.TeamDetail, error)
+	createFn   func(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
+	updateFn   func(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
+	patchFn    func(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error)
+	deleteFn   func(uid, facilityCode, userUID string) error
+	addFn      func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+	removeFn   func(teamUID, facilityCode, userUID, memberUID string) (models.TeamDetail, error)
+	replaceFn  func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+}
+
+func (m *teamsServiceMock) GetAllTeams(facilityCode string) ([]models.TeamListItem, error) {
+	if m.getAllFn != nil {
+		return m.getAllFn(facilityCode)
+	}
+	return []models.TeamListItem{}, nil
+}
+
+func (m *teamsServiceMock) GetTeamByUID(uid, facilityCode string) (models.TeamDetail, error) {
+	if m.getByUIDFn != nil {
+		return m.getByUIDFn(uid, facilityCode)
+	}
+	return models.TeamDetail{}, nil
+}
+
+func (m *teamsServiceMock) CreateTeam(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error) {
+	if m.createFn != nil {
+		return m.createFn(facilityCode, userUID, req)
+	}
+	return models.Team{}, nil
+}
+
+func (m *teamsServiceMock) UpdateTeam(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error) {
+	if m.updateFn != nil {
+		return m.updateFn(uid, facilityCode, userUID, req)
+	}
+	return models.Team{}, nil
+}
+
+func (m *teamsServiceMock) PatchTeam(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error) {
+	if m.patchFn != nil {
+		return m.patchFn(uid, facilityCode, userUID, fields)
+	}
+	return models.Team{}, nil
+}
+
+func (m *teamsServiceMock) DeleteTeam(uid, facilityCode, userUID string) error {
+	if m.deleteFn != nil {
+		return m.deleteFn(uid, facilityCode, userUID)
+	}
+	return nil
+}
+
+func (m *teamsServiceMock) AddMembers(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error) {
+	if m.addFn != nil {
+		return m.addFn(teamUID, facilityCode, userUID, userUids)
+	}
+	return models.TeamDetail{}, nil
+}
+
+func (m *teamsServiceMock) RemoveMember(teamUID, facilityCode, userUID, memberUID string) (models.TeamDetail, error) {
+	if m.removeFn != nil {
+		return m.removeFn(teamUID, facilityCode, userUID, memberUID)
+	}
+	return models.TeamDetail{}, nil
+}
+
+func (m *teamsServiceMock) ReplaceMembers(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error) {
+	if m.replaceFn != nil {
+		return m.replaceFn(teamUID, facilityCode, userUID, userUids)
+	}
+	return models.TeamDetail{}, nil
+}
+
+// newContext builds an echo context with the facility/user values the Authorization
+// middleware would normally inject, plus an optional JSON body.
+func newContext(method, target, body string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	var req *http.Request
+	if body != "" {
+		req = httptest.NewRequest(method, target, strings.NewReader(body))
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	} else {
+		req = httptest.NewRequest(method, target, nil)
+	}
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("facilityCode", "B")
+	c.Set("userUID", "actor-uid")
+	return c, rec
+}
+
+func assertHTTPErrorCode(t *testing.T, err error, code int) {
+	t.Helper()
+	var he *echo.HTTPError
+	if assert.True(t, errors.As(err, &he), "expected an echo.HTTPError, got %v", err) {
+		assert.Equal(t, code, he.Code)
+	}
+}
+
+func TestCreateTeam_Success(t *testing.T) {
+	c, rec := newContext(http.MethodPost, "/v1/teams", `{"name":"Vacuum","code":"VAC"}`)
+	svc := &teamsServiceMock{
+		createFn: func(fc, uUID string, req *models.TeamCreateRequest) (models.Team, error) {
+			assert.Equal(t, "B", fc)
+			assert.Equal(t, "actor-uid", uUID)
+			assert.Equal(t, "Vacuum", req.Name)
+			return models.Team{UID: "team-1", Name: req.Name, Code: req.Code}, nil
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.CreateTeam()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusCreated, rec.Code)
+	assert.JSONEq(t, `{"uid":"team-1","name":"Vacuum","code":"VAC","description":""}`, rec.Body.String())
+}
+
+func TestCreateTeam_DuplicateCode_BadRequest(t *testing.T) {
+	c, _ := newContext(http.MethodPost, "/v1/teams", `{"name":"Vacuum","code":"VAC"}`)
+	svc := &teamsServiceMock{
+		createFn: func(fc, uUID string, req *models.TeamCreateRequest) (models.Team, error) {
+			return models.Team{}, ErrDuplicateCode
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.CreateTeam()(c)
+
+	assertHTTPErrorCode(t, err, http.StatusBadRequest)
+}
+
+func TestGetTeamByUID_NotFound(t *testing.T) {
+	c, _ := newContext(http.MethodGet, "/v1/teams/missing", "")
+	c.SetParamNames("uid")
+	c.SetParamValues("missing")
+	svc := &teamsServiceMock{
+		getByUIDFn: func(uid, fc string) (models.TeamDetail, error) {
+			return models.TeamDetail{}, ErrNotFound
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.GetTeamByUID()(c)
+
+	assertHTTPErrorCode(t, err, http.StatusNotFound)
+}
+
+func TestDeleteTeam_Referenced_Conflict(t *testing.T) {
+	c, rec := newContext(http.MethodDelete, "/v1/teams/team-1", "")
+	c.SetParamNames("uid")
+	c.SetParamValues("team-1")
+	svc := &teamsServiceMock{
+		deleteFn: func(uid, fc, uUID string) error {
+			return &ReferencedError{SystemCount: 3, RoomCardCount: 1}
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.DeleteTeam()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusConflict, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"label":"System"`)
+	assert.Contains(t, rec.Body.String(), `"count":3`)
+	assert.Contains(t, rec.Body.String(), `"label":"RoomCard"`)
+}
+
+func TestDeleteTeam_Success(t *testing.T) {
+	c, rec := newContext(http.MethodDelete, "/v1/teams/team-1", "")
+	c.SetParamNames("uid")
+	c.SetParamValues("team-1")
+	h := NewTeamsHandlers(&teamsServiceMock{})
+
+	err := h.DeleteTeam()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRemoveTeamMember_NonMember_Idempotent200(t *testing.T) {
+	c, rec := newContext(http.MethodDelete, "/v1/teams/team-1/members/user-x", "")
+	c.SetParamNames("uid", "userUid")
+	c.SetParamValues("team-1", "user-x")
+	svc := &teamsServiceMock{
+		removeFn: func(teamUID, fc, uUID, memberUID string) (models.TeamDetail, error) {
+			// user not a member -> service returns the unchanged detail, no error
+			return models.TeamDetail{UID: "team-1", Name: "Vacuum", Members: []models.TeamMember{}}, nil
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.RemoveTeamMember()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+}
+
+func TestRemoveTeamMember_TeamMissing_404(t *testing.T) {
+	c, _ := newContext(http.MethodDelete, "/v1/teams/missing/members/user-x", "")
+	c.SetParamNames("uid", "userUid")
+	c.SetParamValues("missing", "user-x")
+	svc := &teamsServiceMock{
+		removeFn: func(teamUID, fc, uUID, memberUID string) (models.TeamDetail, error) {
+			return models.TeamDetail{}, ErrNotFound
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.RemoveTeamMember()(c)
+
+	assertHTTPErrorCode(t, err, http.StatusNotFound)
+}
+
+func TestAddTeamMembers_InvalidUids_BadRequest(t *testing.T) {
+	c, _ := newContext(http.MethodPost, "/v1/teams/team-1/members", `{"userUids":["good","bad"]}`)
+	c.SetParamNames("uid")
+	c.SetParamValues("team-1")
+	svc := &teamsServiceMock{
+		addFn: func(teamUID, fc, uUID string, userUids []string) (models.TeamDetail, error) {
+			return models.TeamDetail{}, &InvalidMembersError{Uids: []string{"bad"}}
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.AddTeamMembers()(c)
+
+	assertHTTPErrorCode(t, err, http.StatusBadRequest)
+}
+
+func TestPatchTeam_ExplicitNullClearsDescription(t *testing.T) {
+	c, rec := newContext(http.MethodPatch, "/v1/teams/team-1", `{"description":null}`)
+	c.SetParamNames("uid")
+	c.SetParamValues("team-1")
+
+	var captured *models.PatchTeamFields
+	svc := &teamsServiceMock{
+		patchFn: func(uid, fc, uUID string, fields *models.PatchTeamFields) (models.Team, error) {
+			captured = fields
+			return models.Team{UID: "team-1", Name: "Vacuum"}, nil
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.PatchTeam()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	// name absent -> nil; description present but explicit null -> Optional set with Value nil
+	assert.Nil(t, captured.Name)
+	assert.NotNil(t, captured.Description)
+	assert.Nil(t, captured.Description.Value)
+	assert.Nil(t, captured.Code)
+}
+
+func TestPatchTeam_SetsNameAndDescription(t *testing.T) {
+	c, rec := newContext(http.MethodPatch, "/v1/teams/team-1", `{"name":"Cryo","description":"cryogenics team"}`)
+	c.SetParamNames("uid")
+	c.SetParamValues("team-1")
+
+	var captured *models.PatchTeamFields
+	svc := &teamsServiceMock{
+		patchFn: func(uid, fc, uUID string, fields *models.PatchTeamFields) (models.Team, error) {
+			captured = fields
+			return models.Team{UID: "team-1", Name: "Cryo", Description: "cryogenics team"}, nil
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.PatchTeam()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.NotNil(t, captured.Name)
+	assert.Equal(t, "Cryo", *captured.Name)
+	assert.NotNil(t, captured.Description)
+	assert.NotNil(t, captured.Description.Value)
+	assert.Equal(t, "cryogenics team", *captured.Description.Value)
+}

--- a/services/teams-service/teams-membership-handlers.go
+++ b/services/teams-service/teams-membership-handlers.go
@@ -1,0 +1,122 @@
+package teamsservice
+
+import (
+	"errors"
+	"net/http"
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/teams-service/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
+)
+
+// AddTeamMembers Add team members godoc
+// @Summary Add team members
+// @Description Add one or more users to a team (idempotent). All uids must be users in the facility.
+// @Tags Teams
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param uid path string true "team uid"
+// @Param members body models.TeamMembersRequest true "User uids"
+// @Success 200 {object} models.TeamDetail
+// @Failure 400 "Bad Request"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid}/members [post]
+func (h *TeamsHandlers) AddTeamMembers() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+
+		req := new(models.TeamMembersRequest)
+		if err := c.Bind(req); err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		detail, err := h.teamsService.AddMembers(uid, facilityCode, userUID, req.UserUids)
+		if err != nil {
+			return membershipError(err, "Error adding team members")
+		}
+
+		return c.JSON(http.StatusOK, detail)
+	}
+}
+
+// RemoveTeamMember Remove team member godoc
+// @Summary Remove a team member
+// @Description Remove a single user from a team. Idempotent (200 even if the user was not a member).
+// @Tags Teams
+// @Security BearerAuth
+// @Produce json
+// @Param uid path string true "team uid"
+// @Param userUid path string true "user uid"
+// @Success 200 {object} models.TeamDetail
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid}/members/{userUid} [delete]
+func (h *TeamsHandlers) RemoveTeamMember() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+		memberUID := c.Param("userUid")
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		detail, err := h.teamsService.RemoveMember(uid, facilityCode, userUID, memberUID)
+		if err != nil {
+			return membershipError(err, "Error removing team member")
+		}
+
+		return c.JSON(http.StatusOK, detail)
+	}
+}
+
+// ReplaceTeamMembers Replace team members godoc
+// @Summary Replace team members
+// @Description Replace the entire member set of a team with the supplied user uids (add + remove diff).
+// @Tags Teams
+// @Security BearerAuth
+// @Accept json
+// @Produce json
+// @Param uid path string true "team uid"
+// @Param members body models.TeamMembersRequest true "User uids"
+// @Success 200 {object} models.TeamDetail
+// @Failure 400 "Bad Request"
+// @Failure 404 "Not Found"
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/{uid}/members [put]
+func (h *TeamsHandlers) ReplaceTeamMembers() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+
+		req := new(models.TeamMembersRequest)
+		if err := c.Bind(req); err != nil {
+			return helpers.BadRequest(err.Error())
+		}
+
+		facilityCode := c.Get("facilityCode").(string)
+		userUID := c.Get("userUID").(string)
+
+		detail, err := h.teamsService.ReplaceMembers(uid, facilityCode, userUID, req.UserUids)
+		if err != nil {
+			return membershipError(err, "Error replacing team members")
+		}
+
+		return c.JSON(http.StatusOK, detail)
+	}
+}
+
+// membershipError maps service errors to HTTP responses for the membership endpoints.
+func membershipError(err error, logMsg string) error {
+	if errors.Is(err, ErrNotFound) {
+		return echo.ErrNotFound
+	}
+	if isClientError(err) {
+		return helpers.BadRequest(err.Error())
+	}
+	log.Error().Err(err).Msg(logMsg)
+	return echo.ErrInternalServerError
+}

--- a/services/teams-service/teams-membership-service.go
+++ b/services/teams-service/teams-membership-service.go
@@ -1,0 +1,211 @@
+package teamsservice
+
+import (
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/teams-service/models"
+
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+)
+
+func (svc *TeamsService) AddMembers(teamUID, facilityCode, userUID string, userUids []string) (result models.TeamDetail, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	if _, err = svc.getTeam(session, teamUID, facilityCode); err != nil {
+		return result, err
+	}
+
+	userUids = dedupeNonEmpty(userUids)
+	if len(userUids) == 0 {
+		return result, ErrValidation
+	}
+
+	if err = svc.validateMembers(session, facilityCode, userUids); err != nil {
+		return result, err
+	}
+
+	err = helpers.WriteNeo4jAndReturnNothingMultipleQueries(session,
+		MergeTeamMembersQuery(teamUID, facilityCode, userUids),
+		TeamMembershipAuditQuery(teamUID, userUID, buildMembershipChanges(userUids, nil)))
+	if err != nil {
+		return result, err
+	}
+
+	return svc.getTeamDetail(session, teamUID, facilityCode)
+}
+
+func (svc *TeamsService) RemoveMember(teamUID, facilityCode, userUID, memberUID string) (result models.TeamDetail, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	detail, err := svc.getTeamDetail(session, teamUID, facilityCode)
+	if err != nil {
+		return result, err
+	}
+
+	// idempotent: if the user is not a member, no write / no audit noise
+	if !containsMember(detail.Members, memberUID) {
+		return detail, nil
+	}
+
+	err = helpers.WriteNeo4jAndReturnNothingMultipleQueries(session,
+		RemoveTeamMembersQuery(teamUID, []string{memberUID}),
+		TeamMembershipAuditQuery(teamUID, userUID, buildMembershipChanges(nil, []string{memberUID})))
+	if err != nil {
+		return result, err
+	}
+
+	return svc.getTeamDetail(session, teamUID, facilityCode)
+}
+
+func (svc *TeamsService) ReplaceMembers(teamUID, facilityCode, userUID string, userUids []string) (result models.TeamDetail, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	if _, err = svc.getTeam(session, teamUID, facilityCode); err != nil {
+		return result, err
+	}
+
+	target := dedupeNonEmpty(userUids)
+	if len(target) > 0 {
+		if err = svc.validateMembers(session, facilityCode, target); err != nil {
+			return result, err
+		}
+	}
+
+	currentUids, err := svc.getMemberUids(session, teamUID)
+	if err != nil {
+		return result, err
+	}
+
+	toAdd := sliceDifference(target, currentUids)
+	toRemove := sliceDifference(currentUids, target)
+
+	if len(toAdd) == 0 && len(toRemove) == 0 {
+		return svc.getTeamDetail(session, teamUID, facilityCode)
+	}
+
+	queries := make([]helpers.DatabaseQuery, 0, 3)
+	if len(toRemove) > 0 {
+		queries = append(queries, RemoveTeamMembersQuery(teamUID, toRemove))
+	}
+	if len(toAdd) > 0 {
+		queries = append(queries, MergeTeamMembersQuery(teamUID, facilityCode, toAdd))
+	}
+	queries = append(queries, TeamMembershipAuditQuery(teamUID, userUID, buildMembershipChanges(toAdd, toRemove)))
+
+	if err = helpers.WriteNeo4jAndReturnNothingMultipleQueries(session, queries...); err != nil {
+		return result, err
+	}
+
+	return svc.getTeamDetail(session, teamUID, facilityCode)
+}
+
+// validateMembers ensures every uid is a User in the facility; otherwise returns
+// InvalidMembersError listing the offending uids (hard-fail, nobody is linked).
+func (svc *TeamsService) validateMembers(session neo4j.Session, facilityCode string, userUids []string) error {
+	valid, err := helpers.GetNeo4jSingleRecordSingleValue[[]interface{}](session, ValidateTeamMemberUidsQuery(facilityCode, userUids))
+	if err != nil {
+		return err
+	}
+	validSet := toStringSet(valid)
+	var invalid []string
+	for _, uid := range userUids {
+		if _, ok := validSet[uid]; !ok {
+			invalid = append(invalid, uid)
+		}
+	}
+	if len(invalid) > 0 {
+		return &InvalidMembersError{Uids: invalid}
+	}
+	return nil
+}
+
+func (svc *TeamsService) getTeamDetail(session neo4j.Session, uid, facilityCode string) (models.TeamDetail, error) {
+	detail, err := helpers.GetNeo4jSingleRecordAndMapToStruct[models.TeamDetail](session, GetTeamByUIDQuery(uid, facilityCode))
+	if err != nil {
+		if isNoRecords(err) {
+			return models.TeamDetail{}, ErrNotFound
+		}
+		return models.TeamDetail{}, err
+	}
+	if detail.Members == nil {
+		detail.Members = []models.TeamMember{}
+	}
+	return detail, nil
+}
+
+func (svc *TeamsService) getMemberUids(session neo4j.Session, teamUID string) ([]string, error) {
+	uids, err := helpers.GetNeo4jSingleRecordSingleValue[[]interface{}](session, GetTeamMemberUidsQuery(teamUID))
+	if err != nil {
+		return nil, err
+	}
+	result := make([]string, 0, len(uids))
+	for _, u := range uids {
+		if s, ok := u.(string); ok {
+			result = append(result, s)
+		}
+	}
+	return result, nil
+}
+
+func buildMembershipChanges(added, removed []string) string {
+	changes := []helpers.ChangeEntry{}
+	if len(added) > 0 {
+		changes = append(changes, helpers.ChangeEntry{Field: "membersAdded", Type: "membership", NewValue: added})
+	}
+	if len(removed) > 0 {
+		changes = append(changes, helpers.ChangeEntry{Field: "membersRemoved", Type: "membership", OldValue: removed})
+	}
+	return helpers.MarshalChanges(changes)
+}
+
+func containsMember(members []models.TeamMember, uid string) bool {
+	for _, m := range members {
+		if m.UID == uid {
+			return true
+		}
+	}
+	return false
+}
+
+func dedupeNonEmpty(uids []string) []string {
+	seen := map[string]struct{}{}
+	result := make([]string, 0, len(uids))
+	for _, u := range uids {
+		if u == "" {
+			continue
+		}
+		if _, ok := seen[u]; ok {
+			continue
+		}
+		seen[u] = struct{}{}
+		result = append(result, u)
+	}
+	return result
+}
+
+// sliceDifference returns elements in a that are not in b.
+func sliceDifference(a, b []string) []string {
+	bSet := map[string]struct{}{}
+	for _, x := range b {
+		bSet[x] = struct{}{}
+	}
+	var result []string
+	for _, x := range a {
+		if _, ok := bSet[x]; !ok {
+			result = append(result, x)
+		}
+	}
+	return result
+}
+
+func toStringSet(values []interface{}) map[string]struct{} {
+	set := map[string]struct{}{}
+	for _, v := range values {
+		if s, ok := v.(string); ok {
+			set[s] = struct{}{}
+		}
+	}
+	return set
+}

--- a/services/teams-service/teams-membership-service_test.go
+++ b/services/teams-service/teams-membership-service_test.go
@@ -1,0 +1,125 @@
+package teamsservice
+
+import (
+	"encoding/json"
+	"testing"
+
+	"panda/apigateway/services/teams-service/models"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDedupeNonEmpty(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{"nil", nil, []string{}},
+		{"empty slice", []string{}, []string{}},
+		{"drops empties", []string{"a", "", "b", ""}, []string{"a", "b"}},
+		{"drops duplicates, keeps first order", []string{"a", "b", "a", "c", "b"}, []string{"a", "b", "c"}},
+		{"all empty", []string{"", ""}, []string{}},
+		{"clean passthrough", []string{"x", "y", "z"}, []string{"x", "y", "z"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, dedupeNonEmpty(tc.in))
+		})
+	}
+}
+
+func TestSliceDifference(t *testing.T) {
+	cases := []struct {
+		name string
+		a    []string
+		b    []string
+		want []string
+	}{
+		{"disjoint", []string{"a", "b"}, []string{"c", "d"}, []string{"a", "b"}},
+		{"full overlap", []string{"a", "b"}, []string{"a", "b"}, nil},
+		{"partial overlap", []string{"a", "b", "c"}, []string{"b"}, []string{"a", "c"}},
+		{"empty a", nil, []string{"a"}, nil},
+		{"empty b", []string{"a", "b"}, nil, []string{"a", "b"}},
+		{"preserves a order", []string{"c", "a", "b"}, []string{"a"}, []string{"c", "b"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sliceDifference(tc.a, tc.b))
+		})
+	}
+}
+
+// TestReplaceMembersDiff exercises the exact add/remove computation ReplaceMembers performs,
+// locking in replace-all semantics (target set replaces current set) without needing a DB.
+func TestReplaceMembersDiff(t *testing.T) {
+	cases := []struct {
+		name       string
+		current    []string
+		target     []string
+		wantAdd    []string
+		wantRemove []string
+	}{
+		{"add all to empty", []string{}, []string{"a", "b"}, []string{"a", "b"}, nil},
+		{"clear all", []string{"a", "b"}, []string{}, nil, []string{"a", "b"}},
+		{"no change", []string{"a", "b"}, []string{"a", "b"}, nil, nil},
+		{"swap one", []string{"a", "b"}, []string{"a", "c"}, []string{"c"}, []string{"b"}},
+		{"grow", []string{"a"}, []string{"a", "b", "c"}, []string{"b", "c"}, nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			target := dedupeNonEmpty(tc.target)
+			toAdd := sliceDifference(target, tc.current)
+			toRemove := sliceDifference(tc.current, target)
+			assert.Equal(t, tc.wantAdd, toAdd, "toAdd")
+			assert.Equal(t, tc.wantRemove, toRemove, "toRemove")
+		})
+	}
+}
+
+func TestBuildMembershipChanges(t *testing.T) {
+	t.Run("added only", func(t *testing.T) {
+		entries := unmarshalChanges(t, buildMembershipChanges([]string{"a", "b"}, nil))
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "membersAdded", entries[0].Field)
+		assert.ElementsMatch(t, []interface{}{"a", "b"}, entries[0].NewValue)
+		assert.Nil(t, entries[0].OldValue)
+	})
+
+	t.Run("removed only", func(t *testing.T) {
+		entries := unmarshalChanges(t, buildMembershipChanges(nil, []string{"x"}))
+		assert.Len(t, entries, 1)
+		assert.Equal(t, "membersRemoved", entries[0].Field)
+		assert.ElementsMatch(t, []interface{}{"x"}, entries[0].OldValue)
+		assert.Nil(t, entries[0].NewValue)
+	})
+
+	t.Run("both", func(t *testing.T) {
+		entries := unmarshalChanges(t, buildMembershipChanges([]string{"a"}, []string{"b"}))
+		assert.Len(t, entries, 2)
+	})
+
+	t.Run("neither yields empty array", func(t *testing.T) {
+		assert.Equal(t, "[]", buildMembershipChanges(nil, nil))
+	})
+}
+
+func TestContainsMember(t *testing.T) {
+	members := []models.TeamMember{{UID: "a"}, {UID: "b"}}
+	assert.True(t, containsMember(members, "b"))
+	assert.False(t, containsMember(members, "z"))
+	assert.False(t, containsMember(nil, "a"))
+}
+
+type changeEntry struct {
+	Field    string      `json:"field"`
+	OldValue interface{} `json:"oldValue"`
+	NewValue interface{} `json:"newValue"`
+}
+
+func unmarshalChanges(t *testing.T, s string) []changeEntry {
+	t.Helper()
+	var entries []changeEntry
+	assert.NoError(t, json.Unmarshal([]byte(s), &entries))
+	return entries
+}

--- a/services/teams-service/teams-routes.go
+++ b/services/teams-service/teams-routes.go
@@ -1,0 +1,23 @@
+package teamsservice
+
+import (
+	m "panda/apigateway/middlewares"
+	"panda/apigateway/shared"
+
+	"github.com/labstack/echo/v4"
+)
+
+func MapTeamsRoutes(e *echo.Echo, h ITeamsHandlers, jwtMiddleware echo.MiddlewareFunc) {
+	// team CRUD
+	e.GET("/v1/teams", m.Authorization(h.GetAllTeams(), shared.ROLE_TEAMS_VIEW, shared.ROLE_ADMIN), jwtMiddleware)
+	e.GET("/v1/teams/:uid", m.Authorization(h.GetTeamByUID(), shared.ROLE_TEAMS_VIEW, shared.ROLE_ADMIN), jwtMiddleware)
+	e.POST("/v1/teams", m.Authorization(h.CreateTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.PUT("/v1/teams/:uid", m.Authorization(h.UpdateTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.PATCH("/v1/teams/:uid", m.Authorization(h.PatchTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.DELETE("/v1/teams/:uid", m.Authorization(h.DeleteTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+
+	// team membership
+	e.POST("/v1/teams/:uid/members", m.Authorization(h.AddTeamMembers(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.PUT("/v1/teams/:uid/members", m.Authorization(h.ReplaceTeamMembers(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.DELETE("/v1/teams/:uid/members/:userUid", m.Authorization(h.RemoveTeamMember(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+}

--- a/services/teams-service/teams-service.go
+++ b/services/teams-service/teams-service.go
@@ -1,0 +1,238 @@
+package teamsservice
+
+import (
+	"errors"
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/teams-service/models"
+	"strings"
+
+	"github.com/google/uuid"
+	"github.com/neo4j/neo4j-go-driver/v4/neo4j"
+)
+
+var (
+	ErrNotFound      = errors.New("team not found")
+	ErrDuplicateCode = errors.New("team with this code already exists in this facility")
+	ErrValidation    = errors.New("invalid team payload")
+)
+
+// ReferencedError is returned when a team cannot be deleted because Systems/RoomCards
+// still reference it. It carries per-label counts for the 409 response.
+type ReferencedError struct {
+	SystemCount   int
+	RoomCardCount int
+}
+
+func (e *ReferencedError) Error() string {
+	return "team is referenced by other entities and cannot be deleted"
+}
+
+// InvalidMembersError is returned when a membership request contains uids that are not
+// Users in the team's facility. It carries the offending uids for the 400 message.
+type InvalidMembersError struct {
+	Uids []string
+}
+
+func (e *InvalidMembersError) Error() string {
+	return "invalid member uids (not users in this facility): " + strings.Join(e.Uids, ", ")
+}
+
+type TeamsService struct {
+	neo4jDriver *neo4j.Driver
+}
+
+type ITeamsService interface {
+	GetAllTeams(facilityCode string) ([]models.TeamListItem, error)
+	GetTeamByUID(uid, facilityCode string) (models.TeamDetail, error)
+	CreateTeam(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
+	UpdateTeam(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
+	PatchTeam(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error)
+	DeleteTeam(uid, facilityCode, userUID string) error
+	AddMembers(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+	RemoveMember(teamUID, facilityCode, userUID, memberUID string) (models.TeamDetail, error)
+	ReplaceMembers(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+}
+
+func NewTeamsService(driver *neo4j.Driver) ITeamsService {
+	return &TeamsService{neo4jDriver: driver}
+}
+
+func (svc *TeamsService) GetAllTeams(facilityCode string) (result []models.TeamListItem, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	result, err = helpers.GetNeo4jArrayOfNodes[models.TeamListItem](session, GetAllTeamsQuery(facilityCode))
+	helpers.ProcessArrayResult(&result, err)
+	return result, err
+}
+
+func (svc *TeamsService) GetTeamByUID(uid, facilityCode string) (result models.TeamDetail, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	result, err = helpers.GetNeo4jSingleRecordAndMapToStruct[models.TeamDetail](session, GetTeamByUIDQuery(uid, facilityCode))
+	if isNoRecords(err) {
+		return result, ErrNotFound
+	}
+	return result, err
+}
+
+func (svc *TeamsService) CreateTeam(facilityCode, userUID string, req *models.TeamCreateRequest) (result models.Team, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	name := strings.TrimSpace(req.Name)
+	code := strings.TrimSpace(req.Code)
+	if name == "" {
+		return result, ErrValidation
+	}
+
+	if err = svc.ensureCodeUnique(session, code, facilityCode, ""); err != nil {
+		return result, err
+	}
+
+	uid := uuid.New().String()
+	query := CreateTeamQuery(uid, name, code, strings.TrimSpace(req.Description), facilityCode, userUID)
+	return helpers.WriteNeo4jReturnSingleRecordAndMapToStruct[models.Team](session, query)
+}
+
+func (svc *TeamsService) UpdateTeam(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (result models.Team, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	if _, err = svc.getTeam(session, uid, facilityCode); err != nil {
+		return result, err
+	}
+
+	name := strings.TrimSpace(req.Name)
+	code := strings.TrimSpace(req.Code)
+	if name == "" {
+		return result, ErrValidation
+	}
+
+	if err = svc.ensureCodeUnique(session, code, facilityCode, uid); err != nil {
+		return result, err
+	}
+
+	if err = helpers.WriteNeo4jAndReturnNothing(session, UpdateTeamQuery(uid, name, code, req.Description, facilityCode, userUID)); err != nil {
+		return result, err
+	}
+
+	return svc.getTeam(session, uid, facilityCode)
+}
+
+func (svc *TeamsService) PatchTeam(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (result models.Team, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	current, err := svc.getTeam(session, uid, facilityCode)
+	if err != nil {
+		return result, err
+	}
+
+	changes := []helpers.ChangeEntry{}
+
+	if fields.Name != nil {
+		newName := strings.TrimSpace(*fields.Name)
+		if newName == "" {
+			return result, ErrValidation
+		}
+		changes = helpers.AppendIfChanged(changes, "name", helpers.ChangeTypeString, current.Name, newName)
+	}
+
+	if fields.Code != nil {
+		var newCode *string
+		if fields.Code.Value != nil {
+			trimmed := strings.TrimSpace(*fields.Code.Value)
+			newCode = &trimmed
+		}
+		if newCode != nil && *newCode != "" {
+			if err = svc.ensureCodeUnique(session, *newCode, facilityCode, uid); err != nil {
+				return result, err
+			}
+		}
+		changes = helpers.AppendIfChanged(changes, "code", helpers.ChangeTypeString, current.Code, optStringValue(newCode))
+	}
+
+	if fields.Description != nil {
+		var newDesc *string
+		if fields.Description.Value != nil {
+			newDesc = fields.Description.Value
+		}
+		changes = helpers.AppendIfChanged(changes, "description", helpers.ChangeTypeString, current.Description, optStringValue(newDesc))
+	}
+
+	// nothing supplied or nothing actually changed -> no write, no audit noise
+	if len(changes) == 0 {
+		return current, nil
+	}
+
+	query := PatchTeamQuery(uid, facilityCode, userUID, fields, helpers.MarshalChanges(changes))
+	if err = helpers.WriteNeo4jAndReturnNothing(session, query); err != nil {
+		return result, err
+	}
+
+	return svc.getTeam(session, uid, facilityCode)
+}
+
+func (svc *TeamsService) DeleteTeam(uid, facilityCode, userUID string) error {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	if _, err := svc.getTeam(session, uid, facilityCode); err != nil {
+		return err
+	}
+
+	refs, err := helpers.GetNeo4jSingleRecordAndMapToStruct[teamReferences](session, CheckTeamReferencesQuery(uid, facilityCode))
+	if err != nil {
+		return err
+	}
+	if refs.SystemCount > 0 || refs.RoomCardCount > 0 {
+		return &ReferencedError{SystemCount: refs.SystemCount, RoomCardCount: refs.RoomCardCount}
+	}
+
+	return helpers.WriteNeo4jAndReturnNothing(session, DeleteTeamQuery(uid, facilityCode))
+}
+
+// getTeam fetches the plain team (name/code/description), translating no-rows to ErrNotFound.
+func (svc *TeamsService) getTeam(session neo4j.Session, uid, facilityCode string) (models.Team, error) {
+	detail, err := helpers.GetNeo4jSingleRecordAndMapToStruct[models.TeamDetail](session, GetTeamByUIDQuery(uid, facilityCode))
+	if err != nil {
+		if isNoRecords(err) {
+			return models.Team{}, ErrNotFound
+		}
+		return models.Team{}, err
+	}
+	return models.Team{UID: detail.UID, Name: detail.Name, Code: detail.Code, Description: detail.Description}, nil
+}
+
+// ensureCodeUnique rejects a duplicate non-empty code within the facility (excluding excludeUID).
+func (svc *TeamsService) ensureCodeUnique(session neo4j.Session, code, facilityCode, excludeUID string) error {
+	if code == "" {
+		return nil
+	}
+	cnt, err := helpers.GetNeo4jSingleRecordSingleValue[int64](session, CheckTeamCodeExistsQuery(code, facilityCode, excludeUID))
+	if err != nil {
+		return err
+	}
+	if cnt > 0 {
+		return ErrDuplicateCode
+	}
+	return nil
+}
+
+type teamReferences struct {
+	SystemCount   int `json:"systemCount"`
+	RoomCardCount int `json:"roomCardCount"`
+}
+
+func isNoRecords(err error) bool {
+	return errors.Is(err, helpers.ERR_NO_ROWS)
+}
+
+func optStringValue(v *string) interface{} {
+	if v == nil {
+		return nil
+	}
+	return *v
+}

--- a/shared/roles.go
+++ b/shared/roles.go
@@ -44,3 +44,7 @@ const ROLE_PUBLICATIONS_EDIT string = "publications-edit"
 // Zones
 const ROLE_ZONES_VIEW string = "zones-view"
 const ROLE_ZONES_EDIT string = "zones-edit"
+
+// Teams
+const ROLE_TEAMS_VIEW string = "teams-view"
+const ROLE_TEAMS_EDIT string = "teams-edit"


### PR DESCRIPTION
## What

New first-class **Teams module** (`services/teams-service/`) with full team CRUD plus n:n user↔team membership management, built on the new `(:User)-[:BELONGS_TO_TEAM]->(:Team)` relationship.

### Endpoints
| Method | Path | Role | |
|---|---|---|---|
| GET | `/v1/teams` | teams-view / admin | flat list of facility teams + memberCount |
| GET | `/v1/teams/:uid` | teams-view / admin | team + full member list |
| POST | `/v1/teams` | teams-edit / admin | create |
| PUT | `/v1/teams/:uid` | teams-edit / admin | full replace |
| PATCH | `/v1/teams/:uid` | teams-edit / admin | merge-patch (absent≠null) |
| DELETE | `/v1/teams/:uid` | teams-edit / admin | delete, 409 if referenced |
| POST | `/v1/teams/:uid/members` | teams-edit / admin | add members (idempotent) |
| PUT | `/v1/teams/:uid/members` | teams-edit / admin | replace whole member set |
| DELETE | `/v1/teams/:uid/members/:userUid` | teams-edit / admin | remove one member |

## Why

`Team` existed only as a name-only, facility-scoped autocomplete codebook (gated by `codebooks-admin`) with no membership concept. This adds a proper Teams admin surface: richer team params (name/code/description) and the ability to manage which users belong to which teams (many-to-many).

## Design decisions

- **Coexists** with the existing codebook `TEAM` path — that autocomplete GET (used by Systems/RoomCards) and its name-only write path are left untouched; this module is the authoritative full editor.
- **Auth**: new `teams-view` / `teams-edit` roles, and every route also accepts `admin`. Migration creates the Role nodes only — `HAS_ROLE` assignment is done manually out-of-band.
- **Fields**: `name` required; `code` optional but unique per facility when non-empty (app-level check); `description` optional. Facility-scoped via `BELONGS_TO_FACILITY`.
- **Membership**: hard-fail validation — every uid must be a User in the team's facility, else `400` and nobody is linked. Add is idempotent (`MERGE`); replace-all diffs add/remove. All mutation endpoints return the updated `TeamDetail`.
- **Audit**: inline `WAS_UPDATED_BY` edges house-style, including a lightweight membership-change edge with the added/removed uid delta.
- **Delete**: hard `DETACH DELETE`, but `409` (with per-label `relatedNodes` counts for System/RoomCard) if the team is still referenced.
- **Members**: returned full inline incl. disabled users, flagged via `isEnabled`.

## How tested

- Handler unit tests with a `teamsServiceMock` + `httptest` covering the HTTP contracts (201 create, 400 dup-code / invalid-member-uids, 404 not-found, 409 referenced-delete with counts, idempotent 200 member removal, PATCH explicit-null clears). `go test ./services/teams-service/...` passes.
- Full `go build ./...` and `go vet` clean.

## Swagger

Regenerated via `make swagger`; all four `/v1/teams*` path groups present in `docs/` + `open-api-specification/panda-api.yaml`.

## Migration impact

Adds `20260709120000_add_teams_module` (roles `teams-view`/`teams-edit`, `Team_uid_unique` constraint, `Team_name` index). Runs on startup. `BELONGS_TO_TEAM` needs no schema declaration.

## Follow-ups (not in this PR)

- Assign `teams-view`/`teams-edit` to real users (manual, per decision).
- Re-dump `db/schema-simple.json` after applying the migration against the live DB (needs APOC).
