### PR TITLE
feat(systems): responsibility-based edit guard + /can-edit endpoint

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5232,6 +5232,46 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/system/{uid}/can-edit": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whether the caller may edit the system (responsibility bubbles up HAS_SUBSYSTEM) and the responsible users to contact.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Systems"
+                ],
+                "summary": "Can the current user edit this system",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "System UID",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CanEditSystemResult"
+                        }
+                    },
+                    "404": {
+                        "description": "System not found"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/v1/system/{uid}/graph": {
             "get": {
                 "security": [
@@ -6852,6 +6892,20 @@ const docTemplate = `{
                 },
                 "targetUid": {
                     "type": "string"
+                }
+            }
+        },
+        "models.CanEditSystemResult": {
+            "type": "object",
+            "properties": {
+                "responsibles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.SystemResponsible"
+                    }
+                },
+                "result": {
+                    "type": "boolean"
                 }
             }
         },
@@ -8785,6 +8839,26 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "systemToUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.SystemResponsible": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5229,6 +5229,46 @@
                 }
             }
         },
+        "/v1/system/{uid}/can-edit": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Returns whether the caller may edit the system (responsibility bubbles up HAS_SUBSYSTEM) and the responsible users to contact.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Systems"
+                ],
+                "summary": "Can the current user edit this system",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "System UID",
+                        "name": "uid",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CanEditSystemResult"
+                        }
+                    },
+                    "404": {
+                        "description": "System not found"
+                    },
+                    "500": {
+                        "description": "Internal server error"
+                    }
+                }
+            }
+        },
         "/v1/system/{uid}/graph": {
             "get": {
                 "security": [
@@ -6849,6 +6889,20 @@
                 },
                 "targetUid": {
                     "type": "string"
+                }
+            }
+        },
+        "models.CanEditSystemResult": {
+            "type": "object",
+            "properties": {
+                "responsibles": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/models.SystemResponsible"
+                    }
+                },
+                "result": {
+                    "type": "boolean"
                 }
             }
         },
@@ -8782,6 +8836,26 @@
                     "type": "string"
                 },
                 "systemToUid": {
+                    "type": "string"
+                }
+            }
+        },
+        "models.SystemResponsible": {
+            "type": "object",
+            "properties": {
+                "email": {
+                    "type": "string"
+                },
+                "firstName": {
+                    "type": "string"
+                },
+                "lastName": {
+                    "type": "string"
+                },
+                "uid": {
+                    "type": "string"
+                },
+                "username": {
                     "type": "string"
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -162,6 +162,15 @@ definitions:
       targetUid:
         type: string
     type: object
+  models.CanEditSystemResult:
+    properties:
+      responsibles:
+        items:
+          $ref: '#/definitions/models.SystemResponsible'
+        type: array
+      result:
+        type: boolean
+    type: object
   models.CatalogueCategory:
     properties:
       code:
@@ -1445,6 +1454,19 @@ definitions:
       systemFromUid:
         type: string
       systemToUid:
+        type: string
+    type: object
+  models.SystemResponsible:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      uid:
+        type: string
+      username:
         type: string
     type: object
   models.SystemSimpleInfo:
@@ -4697,6 +4719,32 @@ paths:
       security:
       - BearerAuth: []
       summary: Update system
+      tags:
+      - Systems
+  /v1/system/{uid}/can-edit:
+    get:
+      description: Returns whether the caller may edit the system (responsibility
+        bubbles up HAS_SUBSYSTEM) and the responsible users to contact.
+      parameters:
+      - description: System UID
+        in: path
+        name: uid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CanEditSystemResult'
+        "404":
+          description: System not found
+        "500":
+          description: Internal server error
+      security:
+      - BearerAuth: []
+      summary: Can the current user edit this system
       tags:
       - Systems
   /v1/system/{uid}/graph:

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -162,6 +162,15 @@ definitions:
       targetUid:
         type: string
     type: object
+  models.CanEditSystemResult:
+    properties:
+      responsibles:
+        items:
+          $ref: '#/definitions/models.SystemResponsible'
+        type: array
+      result:
+        type: boolean
+    type: object
   models.CatalogueCategory:
     properties:
       code:
@@ -1445,6 +1454,19 @@ definitions:
       systemFromUid:
         type: string
       systemToUid:
+        type: string
+    type: object
+  models.SystemResponsible:
+    properties:
+      email:
+        type: string
+      firstName:
+        type: string
+      lastName:
+        type: string
+      uid:
+        type: string
+      username:
         type: string
     type: object
   models.SystemSimpleInfo:
@@ -4697,6 +4719,32 @@ paths:
       security:
       - BearerAuth: []
       summary: Update system
+      tags:
+      - Systems
+  /v1/system/{uid}/can-edit:
+    get:
+      description: Returns whether the caller may edit the system (responsibility
+        bubbles up HAS_SUBSYSTEM) and the responsible users to contact.
+      parameters:
+      - description: System UID
+        in: path
+        name: uid
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CanEditSystemResult'
+        "404":
+          description: System not found
+        "500":
+          description: Internal server error
+      security:
+      - BearerAuth: []
+      summary: Can the current user edit this system
       tags:
       - Systems
   /v1/system/{uid}/graph:

--- a/services/systems-service/models/model_system.go
+++ b/services/systems-service/models/model_system.go
@@ -362,6 +362,23 @@ type EmployeeInfo struct {
 	Phone     *string `json:"phone,omitempty"`
 }
 
+// CanEditSystemResult is the response of the system edit-guard check: whether the caller may
+// edit the system, plus the responsible users (contacts) resolved by bubbling up HAS_SUBSYSTEM.
+type CanEditSystemResult struct {
+	Result       bool                `json:"result"`
+	Responsibles []SystemResponsible `json:"responsibles"`
+}
+
+// SystemResponsible is a login-capable user responsible for a system (directly via
+// HAS_RESPONSIBLE->Employee->HAS_USER, or via a HAS_RESPONSIBLE_TEAM team membership).
+type SystemResponsible struct {
+	UID       string `json:"uid"`
+	FirstName string `json:"firstName"`
+	LastName  string `json:"lastName"`
+	Username  string `json:"username"`
+	Email     string `json:"email"`
+}
+
 // PhysicalItemDetailExtended contains extended physical item information
 type PhysicalItemDetailExtended struct {
 	UID            string             `json:"uid"`

--- a/services/systems-service/systems-canedit-queries.go
+++ b/services/systems-service/systems-canedit-queries.go
@@ -1,0 +1,62 @@
+package systemsService
+
+import "panda/apigateway/helpers"
+
+// CanEditSystemQuery decides whether userUID may edit the system, and returns the responsible
+// users (contacts). Responsibility bubbles UP the HAS_SUBSYSTEM chain (union of the system and
+// all non-deleted ancestors). A responsible is a login-capable User reached either via
+// HAS_RESPONSIBLE->Employee->HAS_USER or via a HAS_RESPONSIBLE_TEAM team the user BELONGS_TO_TEAM.
+//
+// Result precedence: admin -> true; no systems-edit role -> false; no responsibles anywhere
+// (orphan) -> true; otherwise true iff the caller is among the responsibles. Responsibles are
+// always returned (even when result is false) so the FE can show who to contact.
+func CanEditSystemQuery(systemUID, userUID string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (caller:User{uid:$userUID})
+				OPTIONAL MATCH (caller)-[:HAS_ROLE]->(adminR:Role{code:'admin'})
+				OPTIONAL MATCH (caller)-[:HAS_ROLE]->(editR:Role{code:'systems-edit'})
+				WITH caller, count(adminR) > 0 AS isAdmin, count(editR) > 0 AS hasEdit
+				MATCH (sys:System{uid:$systemUID, deleted:false})
+				OPTIONAL MATCH (ancestor:System)-[:HAS_SUBSYSTEM*1..50]->(sys)
+				WHERE ancestor.deleted = false
+				WITH isAdmin, hasEdit, [sys] + collect(DISTINCT ancestor) AS chain
+				UNWIND chain AS s
+				OPTIONAL MATCH (s)-[:HAS_RESPONSIBLE]->(:Employee)-[:HAS_USER]->(ru:User)
+				OPTIONAL MATCH (s)-[:HAS_RESPONSIBLE_TEAM]->(:Team)<-[:BELONGS_TO_TEAM]-(tu:User)
+				WITH isAdmin, hasEdit,
+					[u IN apoc.coll.toSet(collect(DISTINCT ru) + collect(DISTINCT tu)) WHERE u IS NOT NULL] AS respUsers
+				RETURN {
+					result: CASE
+						WHEN isAdmin THEN true
+						WHEN NOT hasEdit THEN false
+						WHEN size(respUsers) = 0 THEN true
+						ELSE any(u IN respUsers WHERE u.uid = $userUID)
+					END,
+					responsibles: [u IN respUsers | {
+						uid: u.uid,
+						firstName: coalesce(u.firstName, ''),
+						lastName: coalesce(u.lastName, ''),
+						username: coalesce(u.username, ''),
+						email: coalesce(u.email, '')
+					}]
+				} AS canEdit`,
+		ReturnAlias: "canEdit",
+		Parameters: map[string]interface{}{
+			"systemUID": systemUID,
+			"userUID":   userUID,
+		},
+	}
+}
+
+// GetSystemUIDByItemUIDQuery resolves the System that contains a given physical item, so the
+// edit-guard can be applied to physical-item endpoints that identify the item, not the system.
+func GetSystemUIDByItemUIDQuery(itemUID string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (sys:System{deleted:false})-[:CONTAINS_ITEM]->(item{uid:$itemUID})
+				RETURN sys.uid AS systemUID`,
+		ReturnAlias: "systemUID",
+		Parameters: map[string]interface{}{
+			"itemUID": itemUID,
+		},
+	}
+}

--- a/services/systems-service/systems-canedit-queries.go
+++ b/services/systems-service/systems-canedit-queries.go
@@ -10,6 +10,10 @@ import "panda/apigateway/helpers"
 // Result precedence: admin -> true; no systems-edit role -> false; no responsibles anywhere
 // (orphan) -> true; otherwise true iff the caller is among the responsibles. Responsibles are
 // always returned (even when result is false) so the FE can show who to contact.
+//
+// The caller is matched with OPTIONAL MATCH so a missing User node (stale JWT / deleted user)
+// yields hasEdit=false -> result=false (fail-closed), while only a missing/deleted SYSTEM (the
+// required MATCH below) produces ERR_NO_ROWS.
 func CanEditSystemQuery(systemUID, userUID string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
 		Query: `OPTIONAL MATCH (caller:User{uid:$userUID})

--- a/services/systems-service/systems-canedit-queries.go
+++ b/services/systems-service/systems-canedit-queries.go
@@ -12,7 +12,7 @@ import "panda/apigateway/helpers"
 // always returned (even when result is false) so the FE can show who to contact.
 func CanEditSystemQuery(systemUID, userUID string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
-		Query: `MATCH (caller:User{uid:$userUID})
+		Query: `OPTIONAL MATCH (caller:User{uid:$userUID})
 				OPTIONAL MATCH (caller)-[:HAS_ROLE]->(adminR:Role{code:'admin'})
 				OPTIONAL MATCH (caller)-[:HAS_ROLE]->(editR:Role{code:'systems-edit'})
 				WITH caller, count(adminR) > 0 AS isAdmin, count(editR) > 0 AS hasEdit

--- a/services/systems-service/systems-canedit-queries.go
+++ b/services/systems-service/systems-canedit-queries.go
@@ -21,8 +21,8 @@ func CanEditSystemQuery(systemUID, userUID string) helpers.DatabaseQuery {
 				OPTIONAL MATCH (caller)-[:HAS_ROLE]->(editR:Role{code:'systems-edit'})
 				WITH caller, count(adminR) > 0 AS isAdmin, count(editR) > 0 AS hasEdit
 				MATCH (sys:System{uid:$systemUID, deleted:false})
-				OPTIONAL MATCH (ancestor:System)-[:HAS_SUBSYSTEM*1..50]->(sys)
-				WHERE ancestor.deleted = false
+				OPTIONAL MATCH ancestorPath = (ancestor:System)-[:HAS_SUBSYSTEM*1..50]->(sys)
+				WHERE all(n IN nodes(ancestorPath) WHERE n.deleted = false)
 				WITH isAdmin, hasEdit, [sys] + collect(DISTINCT ancestor) AS chain
 				UNWIND chain AS s
 				OPTIONAL MATCH (s)-[:HAS_RESPONSIBLE]->(:Employee)-[:HAS_USER]->(ru:User)
@@ -56,7 +56,7 @@ func CanEditSystemQuery(systemUID, userUID string) helpers.DatabaseQuery {
 // edit-guard can be applied to physical-item endpoints that identify the item, not the system.
 func GetSystemUIDByItemUIDQuery(itemUID string) helpers.DatabaseQuery {
 	return helpers.DatabaseQuery{
-		Query: `MATCH (sys:System{deleted:false})-[:CONTAINS_ITEM]->(item{uid:$itemUID})
+		Query: `MATCH (sys:System{deleted:false})-[:CONTAINS_ITEM]->(item:Item{uid:$itemUID})
 				RETURN sys.uid AS systemUID`,
 		ReturnAlias: "systemUID",
 		Parameters: map[string]interface{}{

--- a/services/systems-service/systems-canedit.go
+++ b/services/systems-service/systems-canedit.go
@@ -1,8 +1,13 @@
 package systemsService
 
 import (
+	"errors"
+	"net/http"
 	"panda/apigateway/helpers"
 	"panda/apigateway/services/systems-service/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/rs/zerolog/log"
 )
 
 // CanEditSystem is the single source of truth for the system edit-guard. It bubbles up the
@@ -11,4 +16,57 @@ import (
 func (svc *SystemsService) CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error) {
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 	return helpers.GetNeo4jSingleRecordAndMapToStruct[models.CanEditSystemResult](session, CanEditSystemQuery(systemUID, userUID))
+}
+
+// CanEditSystem godoc
+// @Summary Can the current user edit this system
+// @Description Returns whether the caller may edit the system (responsibility bubbles up HAS_SUBSYSTEM) and the responsible users to contact.
+// @Tags Systems
+// @Produce json
+// @Security BearerAuth
+// @Param uid path string true "System UID"
+// @Success 200 {object} models.CanEditSystemResult
+// @Failure 404 "System not found"
+// @Failure 500 "Internal server error"
+// @Router /v1/system/{uid}/can-edit [get]
+func (h *SystemsHandlers) CanEditSystem() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		uid := c.Param("uid")
+		userUID := c.Get("userUID").(string)
+
+		result, err := h.systemsService.CanEditSystem(uid, userUID)
+		if err != nil {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
+				return echo.ErrNotFound
+			}
+			log.Error().Err(err).Msg("CanEditSystem")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, result)
+	}
+}
+
+// guardSystemEdit returns echo.ErrForbidden (403) if the caller may not edit ANY of the given
+// systems; nil if allowed. A non-existent system (helpers.ERR_NO_ROWS) passes the guard so the
+// handler's own existence check produces the appropriate 404. Empty uids are skipped.
+func (h *SystemsHandlers) guardSystemEdit(c echo.Context, systemUIDs ...string) error {
+	userUID := c.Get("userUID").(string)
+	for _, uid := range systemUIDs {
+		if uid == "" {
+			continue
+		}
+		res, err := h.systemsService.CanEditSystem(uid, userUID)
+		if err != nil {
+			if errors.Is(err, helpers.ERR_NO_ROWS) {
+				continue
+			}
+			log.Error().Err(err).Msg("guardSystemEdit")
+			return echo.ErrInternalServerError
+		}
+		if !res.Result {
+			return echo.ErrForbidden
+		}
+	}
+	return nil
 }

--- a/services/systems-service/systems-canedit.go
+++ b/services/systems-service/systems-canedit.go
@@ -1,0 +1,14 @@
+package systemsService
+
+import (
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/systems-service/models"
+)
+
+// CanEditSystem is the single source of truth for the system edit-guard. It bubbles up the
+// HAS_SUBSYSTEM chain and returns whether userUID may edit systemUID plus the responsible users.
+// A non-existent/deleted system yields helpers.ERR_NO_ROWS (callers decide 404 vs. pass-through).
+func (svc *SystemsService) CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	return helpers.GetNeo4jSingleRecordAndMapToStruct[models.CanEditSystemResult](session, CanEditSystemQuery(systemUID, userUID))
+}

--- a/services/systems-service/systems-canedit.go
+++ b/services/systems-service/systems-canedit.go
@@ -15,6 +15,7 @@ import (
 // A non-existent/deleted system yields helpers.ERR_NO_ROWS (callers decide 404 vs. pass-through).
 func (svc *SystemsService) CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error) {
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
 	return helpers.GetNeo4jSingleRecordAndMapToStruct[models.CanEditSystemResult](session, CanEditSystemQuery(systemUID, userUID))
 }
 
@@ -22,6 +23,7 @@ func (svc *SystemsService) CanEditSystem(systemUID, userUID string) (models.CanE
 // can be applied to physical-item endpoints. Returns helpers.ERR_NO_ROWS if the item has no system.
 func (svc *SystemsService) GetSystemUIDByItemUID(itemUID string) (string, error) {
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
 	return helpers.GetNeo4jSingleRecordSingleValue[string](session, GetSystemUIDByItemUIDQuery(itemUID))
 }
 

--- a/services/systems-service/systems-canedit.go
+++ b/services/systems-service/systems-canedit.go
@@ -18,6 +18,13 @@ func (svc *SystemsService) CanEditSystem(systemUID, userUID string) (models.CanE
 	return helpers.GetNeo4jSingleRecordAndMapToStruct[models.CanEditSystemResult](session, CanEditSystemQuery(systemUID, userUID))
 }
 
+// GetSystemUIDByItemUID resolves the System containing the given physical item, so the edit-guard
+// can be applied to physical-item endpoints. Returns helpers.ERR_NO_ROWS if the item has no system.
+func (svc *SystemsService) GetSystemUIDByItemUID(itemUID string) (string, error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	return helpers.GetNeo4jSingleRecordSingleValue[string](session, GetSystemUIDByItemUIDQuery(itemUID))
+}
+
 // CanEditSystem godoc
 // @Summary Can the current user edit this system
 // @Description Returns whether the caller may edit the system (responsibility bubbles up HAS_SUBSYSTEM) and the responsible users to contact.
@@ -69,4 +76,18 @@ func (h *SystemsHandlers) guardSystemEdit(c echo.Context, systemUIDs ...string) 
 		}
 	}
 	return nil
+}
+
+// guardSystemEditByItem resolves the physical item's system and applies guardSystemEdit to it.
+// If the item belongs to no system (ERR_NO_ROWS), the guard passes (handler handles the miss).
+func (h *SystemsHandlers) guardSystemEditByItem(c echo.Context, itemUID string) error {
+	systemUID, err := h.systemsService.GetSystemUIDByItemUID(itemUID)
+	if err != nil {
+		if errors.Is(err, helpers.ERR_NO_ROWS) {
+			return nil
+		}
+		log.Error().Err(err).Msg("guardSystemEditByItem")
+		return echo.ErrInternalServerError
+	}
+	return h.guardSystemEdit(c, systemUID)
 }

--- a/services/systems-service/systems-canedit_test.go
+++ b/services/systems-service/systems-canedit_test.go
@@ -1,0 +1,178 @@
+package systemsService
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"panda/apigateway/helpers"
+	"panda/apigateway/services/systems-service/models"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+// canEditServiceMock embeds ISystemsService (a nil interface) so it satisfies the large
+// interface without implementing every method; tests override only what they exercise.
+// Any un-overridden method called would panic — tests are written so that never happens.
+type canEditServiceMock struct {
+	ISystemsService
+	canEditFn func(systemUID, userUID string) (models.CanEditSystemResult, error)
+	itemFn    func(itemUID string) (string, error)
+	calls     *[]string
+}
+
+func (m *canEditServiceMock) CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error) {
+	if m.calls != nil {
+		*m.calls = append(*m.calls, systemUID)
+	}
+	return m.canEditFn(systemUID, userUID)
+}
+
+func (m *canEditServiceMock) GetSystemUIDByItemUID(itemUID string) (string, error) {
+	return m.itemFn(itemUID)
+}
+
+func canEditContext(method, target string) (echo.Context, *httptest.ResponseRecorder) {
+	e := echo.New()
+	req := httptest.NewRequest(method, target, nil)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+	c.Set("userUID", "actor-uid")
+	c.Set("facilityCode", "B")
+	c.Set("userRoles", []string{"systems-edit"})
+	return c, rec
+}
+
+func assertForbidden(t *testing.T, err error) {
+	t.Helper()
+	var he *echo.HTTPError
+	if assert.True(t, errors.As(err, &he), "expected echo.HTTPError, got %v", err) {
+		assert.Equal(t, http.StatusForbidden, he.Code)
+	}
+}
+
+func TestGuardSystemEdit_Allowed(t *testing.T) {
+	c, _ := canEditContext(http.MethodPut, "/v1/system/s1")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{Result: true}, nil
+		},
+	}}
+	assert.NoError(t, h.guardSystemEdit(c, "s1"))
+}
+
+func TestGuardSystemEdit_Forbidden(t *testing.T) {
+	c, _ := canEditContext(http.MethodPut, "/v1/system/s1")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{Result: false}, nil
+		},
+	}}
+	assertForbidden(t, h.guardSystemEdit(c, "s1"))
+}
+
+func TestGuardSystemEdit_MissingSystemPasses(t *testing.T) {
+	c, _ := canEditContext(http.MethodDelete, "/v1/system/missing")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{}, helpers.ERR_NO_ROWS
+		},
+	}}
+	// non-existent system -> guard passes (handler's own flow 404s)
+	assert.NoError(t, h.guardSystemEdit(c, "missing"))
+}
+
+func TestGuardSystemEdit_ForbidIfAnyForbidden(t *testing.T) {
+	c, _ := canEditContext(http.MethodPost, "/v1/systems/move")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			// allowed for s1, forbidden for the destination parent
+			return models.CanEditSystemResult{Result: s == "s1"}, nil
+		},
+	}}
+	assertForbidden(t, h.guardSystemEdit(c, "s1", "destParent"))
+}
+
+func TestGuardSystemEdit_SkipsEmptyUids(t *testing.T) {
+	var calls []string
+	c, _ := canEditContext(http.MethodPost, "/v1/systems/move")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		calls: &calls,
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{Result: true}, nil
+		},
+	}}
+	assert.NoError(t, h.guardSystemEdit(c, "", "s1", ""))
+	assert.Equal(t, []string{"s1"}, calls) // only the non-empty uid triggers a check
+}
+
+func TestCanEditSystemHandler_OK(t *testing.T) {
+	c, rec := canEditContext(http.MethodGet, "/v1/system/s1/can-edit")
+	c.SetParamNames("uid")
+	c.SetParamValues("s1")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{
+				Result:       true,
+				Responsibles: []models.SystemResponsible{{UID: "A", FirstName: "Ann", LastName: "Lee"}},
+			}, nil
+		},
+	}}
+	err := h.CanEditSystem()(c)
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Contains(t, rec.Body.String(), `"result":true`)
+	assert.Contains(t, rec.Body.String(), `"uid":"A"`)
+}
+
+func TestCanEditSystemHandler_NotFound(t *testing.T) {
+	c, _ := canEditContext(http.MethodGet, "/v1/system/missing/can-edit")
+	c.SetParamNames("uid")
+	c.SetParamValues("missing")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{}, helpers.ERR_NO_ROWS
+		},
+	}}
+	err := h.CanEditSystem()(c)
+	var he *echo.HTTPError
+	if assert.True(t, errors.As(err, &he)) {
+		assert.Equal(t, http.StatusNotFound, he.Code)
+	}
+}
+
+func TestGuardByItem_ForbiddenAfterResolve(t *testing.T) {
+	c, _ := canEditContext(http.MethodPut, "/v1/physical-item/item1/properties")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		itemFn: func(itemUID string) (string, error) { return "sysOfItem", nil },
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			assert.Equal(t, "sysOfItem", s)
+			return models.CanEditSystemResult{Result: false}, nil
+		},
+	}}
+	assertForbidden(t, h.guardSystemEditByItem(c, "item1"))
+}
+
+func TestGuardByItem_MissingItemPasses(t *testing.T) {
+	c, _ := canEditContext(http.MethodPut, "/v1/physical-item/item1/properties")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		itemFn: func(itemUID string) (string, error) { return "", helpers.ERR_NO_ROWS },
+	}}
+	assert.NoError(t, h.guardSystemEditByItem(c, "item1"))
+}
+
+func TestUpdateSystemHandler_Forbidden(t *testing.T) {
+	// guard fails -> handler returns 403 before ever calling the (unimplemented) UpdateSystem service
+	c, _ := canEditContext(http.MethodPut, "/v1/system/s1")
+	c.Request().Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	c.SetParamNames("uid")
+	c.SetParamValues("s1")
+	h := &SystemsHandlers{systemsService: &canEditServiceMock{
+		canEditFn: func(s, u string) (models.CanEditSystemResult, error) {
+			return models.CanEditSystemResult{Result: false}, nil
+		},
+	}}
+	assertForbidden(t, h.UpdateSystem()(c))
+}

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -101,6 +101,10 @@ func (h *SystemsHandlers) AssignSpareItem() echo.HandlerFunc {
 
 			userUID := c.Get("userUID").(string)
 
+			if guardErr := h.guardSystemEdit(c, assignSpareRequest.SystemUid, assignSpareRequest.NewParentSystemUid); guardErr != nil {
+				return guardErr
+			}
+
 			response, err := h.systemsService.AssignSpareItem(*assignSpareRequest, userUID)
 
 			if err == nil {
@@ -227,6 +231,13 @@ func (h *SystemsHandlers) CreateNewSystem() echo.HandlerFunc {
 			facilityCode := c.Get("facilityCode").(string)
 			userUID := c.Get("userUID").(string)
 
+			// creating a subsystem requires edit rights on the parent (can't add under a locked system)
+			if system.ParentUID != nil {
+				if guardErr := h.guardSystemEdit(c, *system.ParentUID); guardErr != nil {
+					return guardErr
+				}
+			}
+
 			uid, err := h.systemsService.CreateNewSystem(system, facilityCode, userUID)
 
 			if err == nil {
@@ -272,6 +283,11 @@ func (h *SystemsHandlers) CreateNewSystemFromJira() echo.HandlerFunc {
 			return helpers.BadRequest(err.Error())
 		}
 
+		// importing under a parent requires edit rights on that parent
+		if guardErr := h.guardSystemEdit(c, request.ParentSystemUID); guardErr != nil {
+			return guardErr
+		}
+
 		result, err := h.systemsService.CreateNewSystemFromJira(facilityCode, userUID, userRoles, request)
 
 		if err == nil {
@@ -312,6 +328,10 @@ func (h *SystemsHandlers) UpdateSystem() echo.HandlerFunc {
 			userUID := c.Get("userUID").(string)
 			system.UID = c.Param("uid")
 
+			if guardErr := h.guardSystemEdit(c, system.UID); guardErr != nil {
+				return guardErr
+			}
+
 			err := h.systemsService.UpdateSystem(system, facilityCode, userUID)
 
 			if err == nil {
@@ -342,6 +362,10 @@ func (h *SystemsHandlers) DeleteSystemRecursive() echo.HandlerFunc {
 		//get uid path param
 		uid := c.Param("uid")
 		userUid := c.Get("userUID").(string)
+
+		if guardErr := h.guardSystemEdit(c, uid); guardErr != nil {
+			return guardErr
+		}
 
 		// first check if there are systems with physical items
 		itemsInfo, err := h.systemsService.GetPhysicalItemsBySystemUidRecursive(uid)
@@ -1003,6 +1027,14 @@ func (h *SystemsHandlers) CreateNewSystemRelationship() echo.HandlerFunc {
 		userUID := c.Get("userUID").(string)
 		facilityCode := c.Get("facilityCode").(string)
 
+		// only structural HAS_SUBSYSTEM edges are guarded (functional relationships are exempt);
+		// guard the parent (SystemFromUID) - can't attach a subsystem under a locked system
+		if systemRelationshipRequest.RelationTypeCode == "HAS_SUBSYSTEM" {
+			if guardErr := h.guardSystemEdit(c, systemRelationshipRequest.SystemFromUID); guardErr != nil {
+				return guardErr
+			}
+		}
+
 		newId, err := h.systemsService.CreateNewSystemRelationship(systemRelationshipRequest, facilityCode, userUID)
 		if err == nil {
 			return c.String(http.StatusCreated, strconv.FormatInt(newId, 10))
@@ -1141,6 +1173,10 @@ func (h *SystemsHandlers) UpdatePhysicalItemProperties() echo.HandlerFunc {
 
 		uid := c.Param("uid")
 		userUid := c.Get("userUID").(string)
+
+		if guardErr := h.guardSystemEditByItem(c, uid); guardErr != nil {
+			return guardErr
+		}
 
 		properties := new([]models.PhysicalItemDetail)
 		err := c.Bind(properties)
@@ -1981,6 +2017,10 @@ func (h *SystemsHandlers) MovePhysicalItem() echo.HandlerFunc {
 			userUID := c.Get("userUID").(string)
 			facilityCode := c.Get("facilityCode").(string)
 
+			if guardErr := h.guardSystemEdit(c, movePhysicalItemRequest.SourceSystemUID, movePhysicalItemRequest.DestinationSystemUID, movePhysicalItemRequest.ParentSystemUID); guardErr != nil {
+				return guardErr
+			}
+
 			destinationSystemUID, err := h.systemsService.MovePhysicalItem(movePhysicalItemRequest, userUID, facilityCode)
 
 			if err == nil {
@@ -2026,6 +2066,10 @@ func (h *SystemsHandlers) ReplacePhysicalItems() echo.HandlerFunc {
 			userUID := c.Get("userUID").(string)
 			facilityCode := c.Get("facilityCode").(string)
 
+			if guardErr := h.guardSystemEdit(c, movePhysicalItemRequest.SourceSystemUID, movePhysicalItemRequest.DestinationSystemUID, movePhysicalItemRequest.ParentSystemUID); guardErr != nil {
+				return guardErr
+			}
+
 			destinationSystemUID, err := h.systemsService.ReplacePhysicalItems(movePhysicalItemRequest, userUID, facilityCode)
 
 			if err == nil {
@@ -2069,6 +2113,13 @@ func (h *SystemsHandlers) MoveSystems() echo.HandlerFunc {
 			log.Info().Msgf("Move systems request: %+v", moveSystemsRequest)
 
 			userUID := c.Get("userUID").(string)
+
+			// require edit rights on every moved system AND the destination parent (can't move under a locked system)
+			guardTargets := append([]string{}, moveSystemsRequest.SystemsToMoveUids...)
+			guardTargets = append(guardTargets, moveSystemsRequest.TargetParentSystemUid)
+			if guardErr := h.guardSystemEdit(c, guardTargets...); guardErr != nil {
+				return guardErr
+			}
 
 			destinationSystemUID, err := h.systemsService.MoveSystems(moveSystemsRequest, userUID)
 

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -70,6 +70,7 @@ type ISystemsHandlers interface {
 	AssignSpareItem() echo.HandlerFunc
 	GetSystemSparePartsDetail() echo.HandlerFunc
 	CreateBatchRelationships() echo.HandlerFunc
+	CanEditSystem() echo.HandlerFunc
 }
 
 // NewCommentsHandlers Comments handlers constructor

--- a/services/systems-service/systems-routes.go
+++ b/services/systems-service/systems-routes.go
@@ -30,17 +30,19 @@ func MapSystemsRoutes(e *echo.Echo, h ISystemsHandlers, jwtMiddleware echo.Middl
 	//get system image - base64string
 	e.GET("/v1/system/:uid/image", m.Authorization(h.GetSystemImageByUid(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
 
-	e.POST("/v1/system", m.Authorization(h.CreateNewSystem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
-	e.POST("/v1/system/jira-import", m.Authorization(h.CreateNewSystemFromJira(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/system", m.Authorization(h.CreateNewSystem(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.POST("/v1/system/jira-import", m.Authorization(h.CreateNewSystemFromJira(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 	// get system detail by uid
 	e.GET("/v1/system/:uid", m.Authorization(h.GetSystemDetail(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
 	// get system spare parts detail by uid
 	e.GET("/v1/system/:uid/spare-parts-detail", m.Authorization(h.GetSystemSparePartsDetail(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
+	// can the current user edit this system (responsibility bubbles up HAS_SUBSYSTEM) - view-gated so viewers can pre-check
+	e.GET("/v1/system/:uid/can-edit", m.Authorization(h.CanEditSystem(), shared.ROLE_SYSTEMS_VIEW, shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 	//save new system/sub-system
-	e.PUT("/v1/system/:uid", m.Authorization(h.UpdateSystem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
-	e.DELETE("/v1/system/:uid", m.Authorization(h.DeleteSystemRecursive(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.PUT("/v1/system/:uid", m.Authorization(h.UpdateSystem(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+	e.DELETE("/v1/system/:uid", m.Authorization(h.DeleteSystemRecursive(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 	// this one is only becasue of bad request from ui for now
-	e.POST("/v1/system/:xxx", m.Authorization(h.CreateNewSystem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/system/:xxx", m.Authorization(h.CreateNewSystem(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
 	// get systems for relationship
 	e.GET("/v1/systems/for-relationship", m.Authorization(h.GetSystemsForRelationship(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
@@ -54,8 +56,8 @@ func MapSystemsRoutes(e *echo.Echo, h ISystemsHandlers, jwtMiddleware echo.Middl
 	// delete system relationship
 	e.DELETE("/v1/system/relationship/:uid", m.Authorization(h.DeleteSystemRelationship(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
 
-	// create new system relationship
-	e.POST("/v1/system/relationship/:uid", m.Authorization(h.CreateNewSystemRelationship(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	// create new system relationship (guarded only when creating a HAS_SUBSYSTEM edge)
+	e.POST("/v1/system/relationship/:uid", m.Authorization(h.CreateNewSystemRelationship(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
 	// batch create system relationships
 	e.POST("/v1/system/relationships/batch", m.Authorization(h.CreateBatchRelationships(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
@@ -64,7 +66,7 @@ func MapSystemsRoutes(e *echo.Echo, h ISystemsHandlers, jwtMiddleware echo.Middl
 
 	e.GET("/v1/physical-item/:uid/properties", m.Authorization(h.GetPhysicalItemProperties(), shared.ROLE_SYSTEMS_VIEW, shared.ROLE_CATALOGUE_VIEW, shared.ROLE_ORDERS_VIEW), jwtMiddleware)
 
-	e.PUT("/v1/physical-item/:uid/properties", m.Authorization(h.UpdatePhysicalItemProperties(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.PUT("/v1/physical-item/:uid/properties", m.Authorization(h.UpdatePhysicalItemProperties(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
 	e.GET("/v1/system/:uid/history", m.Authorization(h.GetSystemHistory(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
 
@@ -112,14 +114,14 @@ func MapSystemsRoutes(e *echo.Echo, h ISystemsHandlers, jwtMiddleware echo.Middl
 
 	e.POST("/v1/systems/reload", m.Authorization(h.GetSystemsTreeByUids(), shared.ROLE_SYSTEMS_VIEW), jwtMiddleware)
 
-	e.POST("/v1/physical-item/move", m.Authorization(h.MovePhysicalItem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/physical-item/move", m.Authorization(h.MovePhysicalItem(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
-	e.POST("/v1/physical-item/replace", m.Authorization(h.ReplacePhysicalItems(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/physical-item/replace", m.Authorization(h.ReplacePhysicalItems(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
-	e.POST("/v1/systems/move", m.Authorization(h.MoveSystems(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/systems/move", m.Authorization(h.MoveSystems(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
 	// copy system(s) under an existing destination parent system
 	e.PUT("/v1/systems/copy", m.Authorization(h.CopySystem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
 
-	e.POST("/v1/system/:systemUid/assign-spare", m.Authorization(h.AssignSpareItem(), shared.ROLE_SYSTEMS_EDIT), jwtMiddleware)
+	e.POST("/v1/system/:systemUid/assign-spare", m.Authorization(h.AssignSpareItem(), shared.ROLE_SYSTEMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 }

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -82,6 +82,7 @@ type ISystemsService interface {
 	GetPhysicalItemsBySystemUidRecursive(systemUid string) (result []models.SystemPhysicalItemInfo, err error)
 	AssignSpareItem(request models.AssignSpareRequest, userUID string) (models.AssignSpareResponse, error)
 	CreateBatchRelationships(request *models.BatchRelationshipRequest, facilityCode, userUID string) (models.BatchRelationshipResponse, error)
+	CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error)
 }
 
 var (

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -83,6 +83,7 @@ type ISystemsService interface {
 	AssignSpareItem(request models.AssignSpareRequest, userUID string) (models.AssignSpareResponse, error)
 	CreateBatchRelationships(request *models.BatchRelationshipRequest, facilityCode, userUID string) (models.BatchRelationshipResponse, error)
 	CanEditSystem(systemUID, userUID string) (models.CanEditSystemResult, error)
+	GetSystemUIDByItemUID(itemUID string) (string, error)
 }
 
 var (


### PR DESCRIPTION
## What

Adds a **responsibility-based edit guard** for systems. A user may edit a system only if they are responsible for it — directly (`HAS_RESPONSIBLE`→Employee→User) or via a responsible team (`HAS_RESPONSIBLE_TEAM`→Team←`BELONGS_TO_TEAM`←User) — with responsibility **inherited up** the `HAS_SUBSYSTEM` hierarchy.

### New surface
- **`CanEditSystem(systemUID, userUID)`** — single source of truth. Bubbles up `HAS_SUBSYSTEM` (union of the system + all non-deleted ancestors), returns `{result, responsibles[]}`.
- **`GET /v1/system/:uid/can-edit`** (view-gated) → `{result: bool, responsibles: [{uid,firstName,lastName,username,email}]}` for the FE to pre-check and show who to contact.
- **`guardSystemEdit(...)`** applied to the core system-mutating endpoints → **403 Forbidden** when not allowed.

### Result precedence (in-Cypher)
`admin → true` · `no systems-edit role → false` · `no responsibles anywhere (orphan) → true` · else `caller ∈ chain responsibles`.

## Guarded endpoints
UpdateSystem (`:uid`), DeleteSystemRecursive (`:uid`), CreateNewSystem (parent), CreateNewSystemFromJira (parent), AssignSpareItem (body `SystemUid` + `NewParentSystemUid`), MoveSystems (**every** moved system **and** destination parent), UpdatePhysicalItemProperties (item→system), MovePhysicalItem / ReplacePhysicalItems (source + destination + parent), and CreateNewSystemRelationship **only when the type is `HAS_SUBSYSTEM`** (guards the parent).

## Exempt (by design)
- **Orders** — orders-service mutates Systems via its own Cypher and never calls systems-service, so the order edit flow is untouched (procurement can still change params).
- CopySystem, functional relationships (`IS_RELATED_TO`/`IS_SPARE_FOR`/…, batch, delete), system-code, sync-locations, global RecalculateSpareParts, SaveNewSystemCodes, system-type taxonomy.

## Decisions
- Bubble-up = union of all ancestors (soft-deleted systems excluded).
- Orphan systems (no responsibles in the chain) → any `systems-edit` user may edit.
- **Admin always edits**: `admin` is a flat role here (not a superset), so `ROLE_ADMIN` was added to the guarded route gates so admins reach the handler and the `isAdmin` branch grants them.
- Responsibles = login-capable users only (Employees without a linked User excluded).
- Guard runs per-uid in a loop (bulk ops are infrequent admin actions).

## Dependency note
The team-membership branch of responsibility uses `BELONGS_TO_TEAM`, introduced in the Teams module PR (#427). Until that merges and `BELONGS_TO_TEAM` edges exist, the `OPTIONAL MATCH` for the team path simply matches nothing (valid Cypher regardless) — the `HAS_RESPONSIBLE` path works immediately; team-based responsibility activates once #427 is merged.

## How tested
- 10 handler/guard unit tests (interface-embedding mock): allow / forbid / missing-system-passes / forbid-if-any / skip-empty / item-resolution / can-edit 200+404 / UpdateSystem 403. `go test ./services/systems-service/ -run 'TestGuard|TestCanEdit|TestUpdateSystemHandler'` passes.
- Full `go build ./...` + `go vet` clean.
- End-to-end DB verification (bubble-up inheritance, team path, orphan, move dest-parent 403, order-path unguarded) to be exercised against the local stack — steps in the plan.

## Swagger
Regenerated (`make swagger`); `/v1/system/{uid}/can-edit` + `CanEditSystemResult`/`SystemResponsible` present in `docs/` and `open-api-specification/panda-api.yaml`.
