### PR TITLE
feat(teams): assignable users endpoint for member picker

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -6372,6 +6372,45 @@ const docTemplate = `{
                 }
             }
         },
+        "/v1/teams/assignable-users": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get enabled users of the current facility for the team member picker. Optional case-insensitive search across name/username/email.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get assignable facility users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Case-insensitive substring filter across firstName/lastName/username/email",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TeamMember"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/teams/{uid}": {
             "get": {
                 "security": [

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -6369,6 +6369,45 @@
                 }
             }
         },
+        "/v1/teams/assignable-users": {
+            "get": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Get enabled users of the current facility for the team member picker. Optional case-insensitive search across name/username/email.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Teams"
+                ],
+                "summary": "Get assignable facility users",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Case-insensitive substring filter across firstName/lastName/username/email",
+                        "name": "search",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/models.TeamMember"
+                            }
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error"
+                    }
+                }
+            }
+        },
         "/v1/teams/{uid}": {
             "get": {
                 "security": [

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -6201,6 +6201,31 @@ paths:
       summary: Remove a team member
       tags:
       - Teams
+  /v1/teams/assignable-users:
+    get:
+      description: Get enabled users of the current facility for the team member picker.
+        Optional case-insensitive search across name/username/email.
+      parameters:
+      - description: Case-insensitive substring filter across firstName/lastName/username/email
+        in: query
+        name: search
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TeamMember'
+            type: array
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get assignable facility users
+      tags:
+      - Teams
   /v1/users/{userUID}/disable:
     post:
       description: Disables user account and invalidates auth status cache.

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -6201,6 +6201,31 @@ paths:
       summary: Remove a team member
       tags:
       - Teams
+  /v1/teams/assignable-users:
+    get:
+      description: Get enabled users of the current facility for the team member picker.
+        Optional case-insensitive search across name/username/email.
+      parameters:
+      - description: Case-insensitive substring filter across firstName/lastName/username/email
+        in: query
+        name: search
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/models.TeamMember'
+            type: array
+        "500":
+          description: Internal Server Error
+      security:
+      - BearerAuth: []
+      summary: Get assignable facility users
+      tags:
+      - Teams
   /v1/users/{userUID}/disable:
     post:
       description: Disables user account and invalidates auth status cache.

--- a/services/teams-service/teams-db-queries.go
+++ b/services/teams-service/teams-db-queries.go
@@ -44,6 +44,29 @@ func GetTeamByUIDQuery(uid, facilityCode string) helpers.DatabaseQuery {
 	}
 }
 
+// GetAssignableUsersQuery returns enabled Users in the facility, for the team member picker.
+// Disabled users are excluded. An empty search matches everyone; otherwise it is a
+// case-insensitive substring match across firstName, lastName, username and email.
+func GetAssignableUsersQuery(facilityCode, search string) helpers.DatabaseQuery {
+	return helpers.DatabaseQuery{
+		Query: `MATCH (u:User)-[:BELONGS_TO_FACILITY]->(:Facility{code:$facilityCode})
+				WHERE coalesce(u.isEnabled, false) = true
+				  AND ($search = '' OR toLower(coalesce(u.firstName, '')) CONTAINS toLower($search)
+				       OR toLower(coalesce(u.lastName, '')) CONTAINS toLower($search)
+				       OR toLower(coalesce(u.username, '')) CONTAINS toLower($search)
+				       OR toLower(coalesce(u.email, '')) CONTAINS toLower($search))
+				RETURN {uid: u.uid, firstName: coalesce(u.firstName, ''), lastName: coalesce(u.lastName, ''),
+						username: coalesce(u.username, ''), email: coalesce(u.email, ''),
+						isEnabled: coalesce(u.isEnabled, false)} AS user
+				ORDER BY user.lastName, user.firstName`,
+		ReturnAlias: "user",
+		Parameters: map[string]interface{}{
+			"facilityCode": facilityCode,
+			"search":       search,
+		},
+	}
+}
+
 // CheckTeamCodeExistsQuery counts teams (excluding excludeUID) with the given code in the
 // facility. Only invoked when code is non-empty.
 func CheckTeamCodeExistsQuery(code, facilityCode, excludeUID string) helpers.DatabaseQuery {

--- a/services/teams-service/teams-handlers.go
+++ b/services/teams-service/teams-handlers.go
@@ -19,6 +19,7 @@ type TeamsHandlers struct {
 
 type ITeamsHandlers interface {
 	GetAllTeams() echo.HandlerFunc
+	GetAssignableUsers() echo.HandlerFunc
 	GetTeamByUID() echo.HandlerFunc
 	CreateTeam() echo.HandlerFunc
 	UpdateTeam() echo.HandlerFunc
@@ -53,6 +54,31 @@ func (h *TeamsHandlers) GetAllTeams() echo.HandlerFunc {
 		}
 
 		return c.JSON(http.StatusOK, teams)
+	}
+}
+
+// GetAssignableUsers Get assignable facility users godoc
+// @Summary Get assignable facility users
+// @Description Get enabled users of the current facility for the team member picker. Optional case-insensitive search across name/username/email.
+// @Tags Teams
+// @Security BearerAuth
+// @Produce json
+// @Param search query string false "Case-insensitive substring filter across firstName/lastName/username/email"
+// @Success 200 {array} models.TeamMember
+// @Failure 500 "Internal Server Error"
+// @Router /v1/teams/assignable-users [get]
+func (h *TeamsHandlers) GetAssignableUsers() echo.HandlerFunc {
+	return func(c echo.Context) error {
+		facilityCode := c.Get("facilityCode").(string)
+		search := c.QueryParam("search")
+
+		users, err := h.teamsService.GetAssignableUsers(facilityCode, search)
+		if err != nil {
+			log.Error().Err(err).Msg("Error getting assignable users")
+			return echo.ErrInternalServerError
+		}
+
+		return c.JSON(http.StatusOK, users)
 	}
 }
 

--- a/services/teams-service/teams-handlers_test.go
+++ b/services/teams-service/teams-handlers_test.go
@@ -16,8 +16,9 @@ import (
 // teamsServiceMock is a hand-written ITeamsService stub; each method delegates to an
 // optional func field so individual tests control behavior and capture arguments.
 type teamsServiceMock struct {
-	getAllFn   func(facilityCode string) ([]models.TeamListItem, error)
-	getByUIDFn func(uid, facilityCode string) (models.TeamDetail, error)
+	getAllFn        func(facilityCode string) ([]models.TeamListItem, error)
+	getAssignableFn func(facilityCode, search string) ([]models.TeamMember, error)
+	getByUIDFn      func(uid, facilityCode string) (models.TeamDetail, error)
 	createFn   func(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
 	updateFn   func(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
 	patchFn    func(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error)
@@ -32,6 +33,13 @@ func (m *teamsServiceMock) GetAllTeams(facilityCode string) ([]models.TeamListIt
 		return m.getAllFn(facilityCode)
 	}
 	return []models.TeamListItem{}, nil
+}
+
+func (m *teamsServiceMock) GetAssignableUsers(facilityCode, search string) ([]models.TeamMember, error) {
+	if m.getAssignableFn != nil {
+		return m.getAssignableFn(facilityCode, search)
+	}
+	return []models.TeamMember{}, nil
 }
 
 func (m *teamsServiceMock) GetTeamByUID(uid, facilityCode string) (models.TeamDetail, error) {
@@ -295,4 +303,52 @@ func TestPatchTeam_SetsNameAndDescription(t *testing.T) {
 	assert.NotNil(t, captured.Description)
 	assert.NotNil(t, captured.Description.Value)
 	assert.Equal(t, "cryogenics team", *captured.Description.Value)
+}
+
+func TestGetAssignableUsers_Success_PassesSearch(t *testing.T) {
+	c, rec := newContext(http.MethodGet, "/v1/teams/assignable-users?search=nov", "")
+
+	var capturedFC, capturedSearch string
+	svc := &teamsServiceMock{
+		getAssignableFn: func(fc, search string) ([]models.TeamMember, error) {
+			capturedFC, capturedSearch = fc, search
+			return []models.TeamMember{
+				{UID: "u-1", FirstName: "Jan", LastName: "Novak", Username: "jnovak", Email: "jan@x.io", IsEnabled: true},
+			}, nil
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.GetAssignableUsers()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.Equal(t, "B", capturedFC)
+	assert.Equal(t, "nov", capturedSearch)
+	assert.JSONEq(t, `[{"uid":"u-1","firstName":"Jan","lastName":"Novak","username":"jnovak","email":"jan@x.io","isEnabled":true}]`, rec.Body.String())
+}
+
+func TestGetAssignableUsers_Empty_ReturnsEmptyArray(t *testing.T) {
+	c, rec := newContext(http.MethodGet, "/v1/teams/assignable-users", "")
+	h := NewTeamsHandlers(&teamsServiceMock{})
+
+	err := h.GetAssignableUsers()(c)
+
+	assert.NoError(t, err)
+	assert.Equal(t, http.StatusOK, rec.Code)
+	assert.JSONEq(t, `[]`, rec.Body.String())
+}
+
+func TestGetAssignableUsers_ServiceError_500(t *testing.T) {
+	c, _ := newContext(http.MethodGet, "/v1/teams/assignable-users", "")
+	svc := &teamsServiceMock{
+		getAssignableFn: func(fc, search string) ([]models.TeamMember, error) {
+			return nil, errors.New("db down")
+		},
+	}
+	h := NewTeamsHandlers(svc)
+
+	err := h.GetAssignableUsers()(c)
+
+	assertHTTPErrorCode(t, err, http.StatusInternalServerError)
 }

--- a/services/teams-service/teams-handlers_test.go
+++ b/services/teams-service/teams-handlers_test.go
@@ -19,13 +19,13 @@ type teamsServiceMock struct {
 	getAllFn        func(facilityCode string) ([]models.TeamListItem, error)
 	getAssignableFn func(facilityCode, search string) ([]models.TeamMember, error)
 	getByUIDFn      func(uid, facilityCode string) (models.TeamDetail, error)
-	createFn   func(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
-	updateFn   func(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
-	patchFn    func(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error)
-	deleteFn   func(uid, facilityCode, userUID string) error
-	addFn      func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
-	removeFn   func(teamUID, facilityCode, userUID, memberUID string) (models.TeamDetail, error)
-	replaceFn  func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+	createFn        func(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
+	updateFn        func(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
+	patchFn         func(uid, facilityCode, userUID string, fields *models.PatchTeamFields) (models.Team, error)
+	deleteFn        func(uid, facilityCode, userUID string) error
+	addFn           func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
+	removeFn        func(teamUID, facilityCode, userUID, memberUID string) (models.TeamDetail, error)
+	replaceFn       func(teamUID, facilityCode, userUID string, userUids []string) (models.TeamDetail, error)
 }
 
 func (m *teamsServiceMock) GetAllTeams(facilityCode string) ([]models.TeamListItem, error) {

--- a/services/teams-service/teams-routes.go
+++ b/services/teams-service/teams-routes.go
@@ -16,6 +16,9 @@ func MapTeamsRoutes(e *echo.Echo, h ITeamsHandlers, jwtMiddleware echo.Middlewar
 	e.PATCH("/v1/teams/:uid", m.Authorization(h.PatchTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 	e.DELETE("/v1/teams/:uid", m.Authorization(h.DeleteTeam(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 
+	// assignable facility users for the member picker
+	e.GET("/v1/teams/assignable-users", m.Authorization(h.GetAssignableUsers(), shared.ROLE_TEAMS_VIEW, shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
+
 	// team membership
 	e.POST("/v1/teams/:uid/members", m.Authorization(h.AddTeamMembers(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)
 	e.PUT("/v1/teams/:uid/members", m.Authorization(h.ReplaceTeamMembers(), shared.ROLE_TEAMS_EDIT, shared.ROLE_ADMIN), jwtMiddleware)

--- a/services/teams-service/teams-service.go
+++ b/services/teams-service/teams-service.go
@@ -43,6 +43,7 @@ type TeamsService struct {
 
 type ITeamsService interface {
 	GetAllTeams(facilityCode string) ([]models.TeamListItem, error)
+	GetAssignableUsers(facilityCode, search string) ([]models.TeamMember, error)
 	GetTeamByUID(uid, facilityCode string) (models.TeamDetail, error)
 	CreateTeam(facilityCode, userUID string, req *models.TeamCreateRequest) (models.Team, error)
 	UpdateTeam(uid, facilityCode, userUID string, req *models.TeamUpdateRequest) (models.Team, error)
@@ -62,6 +63,17 @@ func (svc *TeamsService) GetAllTeams(facilityCode string) (result []models.TeamL
 	defer session.Close()
 
 	result, err = helpers.GetNeo4jArrayOfNodes[models.TeamListItem](session, GetAllTeamsQuery(facilityCode))
+	helpers.ProcessArrayResult(&result, err)
+	return result, err
+}
+
+// GetAssignableUsers returns enabled facility users for the team member picker,
+// optionally filtered by a case-insensitive search across name/username/email.
+func (svc *TeamsService) GetAssignableUsers(facilityCode, search string) (result []models.TeamMember, err error) {
+	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
+	defer session.Close()
+
+	result, err = helpers.GetNeo4jArrayOfNodes[models.TeamMember](session, GetAssignableUsersQuery(facilityCode, search))
 	helpers.ProcessArrayResult(&result, err)
 	return result, err
 }


### PR DESCRIPTION
## Context
FE team member picker needs a REST source of assignable facility users with rich fields (`firstName/lastName/username/email/isEnabled`). The only existing REST option, `GET /v1/codebook/USER`, returns just `{uid, name}` — insufficient for a picker showing username/email columns. This adds a facility-scoped list endpoint in teams-service that reuses the member projection shape.

## Endpoint
`GET /v1/teams/assignable-users?search=<optional>`
- Auth: Bearer JWT; role any-of `[teams-view, teams-edit, admin]`
- Facility-scoped implicitly via JWT
- Returns `models.TeamMember[]` (same shape as team member list), sorted by `lastName, firstName`, empty → `[]`
- **Enabled users only** (`isEnabled = true`); `isEnabled` field kept in response for shape parity
- Optional `?search=` — case-insensitive substring across firstName/lastName/username/email; empty/absent = all

## Changes
- `teams-db-queries.go` — `GetAssignableUsersQuery(facilityCode, search)` (`(u:User)-[:BELONGS_TO_FACILITY]->` + enabled + search filter, projection lifted from `GetTeamByUIDQuery`)
- `teams-service.go` — `GetAssignableUsers` service method + interface entry
- `teams-handlers.go` — `GetAssignableUsers` handler + interface entry + swagger annotation
- `teams-routes.go` — route registration
- `teams-handlers_test.go` — 3 handler tests (success+search passthrough, empty array, 500)
- Regenerated swagger docs

No DB migration (no schema change); no `init.go` change (existing `MapTeamsRoutes` wiring).

## Note on uid-space
Membership validation (`ValidateTeamMemberUidsQuery`) does not filter `isEnabled`, so this enabled-only list is a subset of what `/members` accepts. Acceptable for the picker; documented here for reviewers.

## Test
`go build ./...`, `go test ./services/teams-service/...` — pass.