### PR TITLE
feat(systems): directOnly param on leaves endpoints

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5496,7 +5496,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "Only the parent's direct children instead of all descendants",
+                        "description": "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)",
                         "name": "directOnly",
                         "in": "query"
                     }
@@ -5507,6 +5507,9 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/helpers.PaginationResult-models_System"
                         }
+                    },
+                    "400": {
+                        "description": "Bad request"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -5551,7 +5554,7 @@ const docTemplate = `{
                     },
                     {
                         "type": "boolean",
-                        "description": "Only the parent's direct children instead of all descendants",
+                        "description": "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)",
                         "name": "directOnly",
                         "in": "query"
                     }
@@ -5565,6 +5568,9 @@ const docTemplate = `{
                                 "type": "integer"
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Bad request"
                     },
                     "500": {
                         "description": "Internal server error"

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -5493,6 +5493,12 @@ const docTemplate = `{
                         "description": "Column filter JSON",
                         "name": "columnFilter",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only the parent's direct children instead of all descendants",
+                        "name": "directOnly",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -5541,6 +5547,12 @@ const docTemplate = `{
                         "type": "string",
                         "description": "Column filter JSON",
                         "name": "columnFilter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only the parent's direct children instead of all descendants",
+                        "name": "directOnly",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5493,7 +5493,7 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "Only the parent's direct children instead of all descendants",
+                        "description": "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)",
                         "name": "directOnly",
                         "in": "query"
                     }
@@ -5504,6 +5504,9 @@
                         "schema": {
                             "$ref": "#/definitions/helpers.PaginationResult-models_System"
                         }
+                    },
+                    "400": {
+                        "description": "Bad request"
                     },
                     "500": {
                         "description": "Internal server error"
@@ -5548,7 +5551,7 @@
                     },
                     {
                         "type": "boolean",
-                        "description": "Only the parent's direct children instead of all descendants",
+                        "description": "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)",
                         "name": "directOnly",
                         "in": "query"
                     }
@@ -5562,6 +5565,9 @@
                                 "type": "integer"
                             }
                         }
+                    },
+                    "400": {
+                        "description": "Bad request"
                     },
                     "500": {
                         "description": "Internal server error"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5490,6 +5490,12 @@
                         "description": "Column filter JSON",
                         "name": "columnFilter",
                         "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only the parent's direct children instead of all descendants",
+                        "name": "directOnly",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -5538,6 +5544,12 @@
                         "type": "string",
                         "description": "Column filter JSON",
                         "name": "columnFilter",
+                        "in": "query"
+                    },
+                    {
+                        "type": "boolean",
+                        "description": "Only the parent's direct children instead of all descendants",
+                        "name": "directOnly",
                         "in": "query"
                     }
                 ],

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4969,6 +4969,10 @@ paths:
         in: query
         name: columnFilter
         type: string
+      - description: Only the parent's direct children instead of all descendants
+        in: query
+        name: directOnly
+        type: boolean
       produces:
       - application/json
       responses:
@@ -5001,6 +5005,10 @@ paths:
         in: query
         name: columnFilter
         type: string
+      - description: Only the parent's direct children instead of all descendants
+        in: query
+        name: directOnly
+        type: boolean
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -4969,7 +4969,8 @@ paths:
         in: query
         name: columnFilter
         type: string
-      - description: Only the parent's direct children instead of all descendants
+      - description: Only leaf systems directly under the parent (excludes descendants
+          deeper than 1 level)
         in: query
         name: directOnly
         type: boolean
@@ -4980,6 +4981,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/helpers.PaginationResult-models_System'
+        "400":
+          description: Bad request
         "500":
           description: Internal server error
       security:
@@ -5005,7 +5008,8 @@ paths:
         in: query
         name: columnFilter
         type: string
-      - description: Only the parent's direct children instead of all descendants
+      - description: Only leaf systems directly under the parent (excludes descendants
+          deeper than 1 level)
         in: query
         name: directOnly
         type: boolean
@@ -5018,6 +5022,8 @@ paths:
             additionalProperties:
               type: integer
             type: object
+        "400":
+          description: Bad request
         "500":
           description: Internal server error
       security:

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -4969,6 +4969,10 @@ paths:
         in: query
         name: columnFilter
         type: string
+      - description: Only the parent's direct children instead of all descendants
+        in: query
+        name: directOnly
+        type: boolean
       produces:
       - application/json
       responses:
@@ -5001,6 +5005,10 @@ paths:
         in: query
         name: columnFilter
         type: string
+      - description: Only the parent's direct children instead of all descendants
+        in: query
+        name: directOnly
+        type: boolean
       produces:
       - application/json
       responses:

--- a/open-api-specification/panda-api.yaml
+++ b/open-api-specification/panda-api.yaml
@@ -4969,7 +4969,8 @@ paths:
         in: query
         name: columnFilter
         type: string
-      - description: Only the parent's direct children instead of all descendants
+      - description: Only leaf systems directly under the parent (excludes descendants
+          deeper than 1 level)
         in: query
         name: directOnly
         type: boolean
@@ -4980,6 +4981,8 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/helpers.PaginationResult-models_System'
+        "400":
+          description: Bad request
         "500":
           description: Internal server error
       security:
@@ -5005,7 +5008,8 @@ paths:
         in: query
         name: columnFilter
         type: string
-      - description: Only the parent's direct children instead of all descendants
+      - description: Only leaf systems directly under the parent (excludes descendants
+          deeper than 1 level)
         in: query
         name: directOnly
         type: boolean
@@ -5018,6 +5022,8 @@ paths:
             additionalProperties:
               type: integer
             type: object
+        "400":
+          description: Bad request
         "500":
           description: Internal server error
       security:

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -1284,7 +1284,8 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	WITH DISTINCT sys
 	`, leavesTraversalDepth(directOnly))
 
-	// catalogue category filter changes base query
+	// catalogue category filter appends its own MATCH to the base query (it does not
+	// replace it — the parent traversal and the leaf predicate above always apply)
 	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
 	if catalogueCategoryFilter != nil {
 		result.Query += `

--- a/services/systems-service/systems-db-queries.go
+++ b/services/systems-service/systems-db-queries.go
@@ -1243,7 +1243,21 @@ func GetSystemLeavesOrderByClauses(sorting *[]helpers.Sorting) string {
 	return " ORDER BY " + strings.Join(clauses, ", ") + " "
 }
 
-func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, searchString string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter) (result helpers.DatabaseQuery) {
+// leavesTraversalDepth picks how far below the parent a leaf may sit.
+//
+// The caller-facing contract is a boolean ("direct children only") rather than a depth,
+// because the enclosing queries keep their `WHERE NOT (sys)-[:HAS_SUBSYSTEM]->()` clause
+// either way — depth 1 therefore yields exactly the end systems hanging directly off the
+// parent, which is a meaningful set. An arbitrary depth N would not be: it would blend
+// leaves from levels 1..N together.
+func leavesTraversalDepth(directOnly bool) string {
+	if directOnly {
+		return "*1..1"
+	}
+	return "*1..50"
+}
+
+func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, searchString string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter, directOnly bool) (result helpers.DatabaseQuery) {
 	result.Parameters = make(map[string]interface{})
 	result.Parameters["facilityCode"] = facilityCode
 	result.Parameters["parentUID"] = parentUID
@@ -1261,14 +1275,14 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	result.Parameters["limit"] = pagination.PageSize
 	result.Parameters["skip"] = (pagination.Page - 1) * pagination.PageSize
 
-	result.Query = `
+	result.Query = fmt.Sprintf(`
 	MATCH(f:Facility{code:$facilityCode})
 	MATCH(parent:System{uid:$parentUID, deleted:false})-[:BELONGS_TO_FACILITY]->(f)
-	MATCH(parent)-[:HAS_SUBSYSTEM*1..50]->(sys:System{deleted:false})-[:BELONGS_TO_FACILITY]->(f)
+	MATCH(parent)-[:HAS_SUBSYSTEM%s]->(sys:System{deleted:false})-[:BELONGS_TO_FACILITY]->(f)
 	WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})
 	AND ($search = '' OR toLower(sys.name) CONTAINS $search OR toLower(sys.systemCode) CONTAINS $search OR toLower(coalesce(sys.systemCodeOld, '')) CONTAINS $search)
 	WITH DISTINCT sys
-	`
+	`, leavesTraversalDepth(directOnly))
 
 	// catalogue category filter changes base query
 	catalogueCategoryFilter := helpers.GetFilterValueCodebook(filtering, "category")
@@ -1600,20 +1614,20 @@ func GetSystemLeavesByParentUIDQuery(parentUID string, facilityCode string, sear
 	return result
 }
 
-func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string, searchString string, filtering *[]helpers.ColumnFilter) (result helpers.DatabaseQuery) {
+func GetSystemLeavesByParentUIDCountQuery(parentUID string, facilityCode string, searchString string, filtering *[]helpers.ColumnFilter, directOnly bool) (result helpers.DatabaseQuery) {
 	result.Parameters = make(map[string]interface{})
 	result.Parameters["facilityCode"] = facilityCode
 	result.Parameters["parentUID"] = parentUID
 	result.Parameters["search"] = strings.ToLower(strings.TrimSpace(searchString))
 
-	result.Query = `
+	result.Query = fmt.Sprintf(`
 	MATCH(f:Facility{code:$facilityCode})
 	MATCH(parent:System{uid:$parentUID, deleted:false})-[:BELONGS_TO_FACILITY]->(f)
-	MATCH(parent)-[:HAS_SUBSYSTEM*1..50]->(sys:System{deleted:false})-[:BELONGS_TO_FACILITY]->(f)
+	MATCH(parent)-[:HAS_SUBSYSTEM%s]->(sys:System{deleted:false})-[:BELONGS_TO_FACILITY]->(f)
 	WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})
 	AND ($search = '' OR toLower(sys.name) CONTAINS $search OR toLower(sys.systemCode) CONTAINS $search OR toLower(coalesce(sys.systemCodeOld, '')) CONTAINS $search)
 	WITH DISTINCT sys
-	`
+	`, leavesTraversalDepth(directOnly))
 
 	// system-level filters (only need sys, run before physical item matches)
 	// system name

--- a/services/systems-service/systems-db-queries_leaves_test.go
+++ b/services/systems-service/systems-db-queries_leaves_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestGetSystemLeavesByParentUIDQuery_NoFilters(t *testing.T) {
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil, false)
 
 	assert.Equal(t, "systems", query.ReturnAlias)
 	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)")
@@ -25,7 +25,7 @@ func TestGetSystemLeavesByParentUIDQuery_NoFilters(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDQuery_SystemNameFilter(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "name", Value: "Pump"}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "toLower(sys.name) CONTAINS $filterName")
 	assert.Equal(t, "pump", query.Parameters["filterName"])
@@ -33,7 +33,7 @@ func TestGetSystemLeavesByParentUIDQuery_SystemNameFilter(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDQuery_ZoneFilter(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "zone", Value: map[string]interface{}{"uid": "zone-1", "name": "Zone A"}}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:HAS_ZONE]->(zone) WHERE zone.uid = $filterZone")
 	assert.NotContains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_ZONE]->(zone)")
@@ -42,7 +42,7 @@ func TestGetSystemLeavesByParentUIDQuery_ZoneFilter(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDQuery_ItemUsageFilter(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "itemUsage", Value: []interface{}{"usage-1", "usage-2"}}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
 	assert.Contains(t, query.Query, "MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage")
@@ -53,7 +53,7 @@ func TestGetSystemLeavesByParentUIDQuery_PriceFilterAlone(t *testing.T) {
 	min := 100.0
 	max := 500.0
 	filters := []helpers.ColumnFilter{{Id: "price", Value: map[string]interface{}{"min": min, "max": max}}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
 	assert.Contains(t, query.Query, "MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)")
@@ -62,7 +62,7 @@ func TestGetSystemLeavesByParentUIDQuery_PriceFilterAlone(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDQuery_OrderNameCaseInsensitive(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "orderName", Value: "Main Order"}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "toLower(order.name) CONTAINS $filterOrderName")
 	assert.Equal(t, "main order", query.Parameters["filterOrderName"])
@@ -70,7 +70,7 @@ func TestGetSystemLeavesByParentUIDQuery_OrderNameCaseInsensitive(t *testing.T) 
 
 func TestGetSystemLeavesByParentUIDQuery_DynamicPropFilterAlone(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "prop-uid-1", Value: "test-value", Type: "text", PropType: "PHYSICAL_ITEM"}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
 	assert.Contains(t, query.Query, "MATCH(prop{uid: $propUID0})<-[pv]-(physicalItem)")
@@ -78,7 +78,7 @@ func TestGetSystemLeavesByParentUIDQuery_DynamicPropFilterAlone(t *testing.T) {
 }
 
 func TestGetSystemLeavesByParentUIDQuery_ResponsibleVariableName(t *testing.T) {
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil, false)
 
 	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_RESPONSIBLE]->(responsible)")
 	assert.NotContains(t, query.Query, "responsilbe")
@@ -86,15 +86,44 @@ func TestGetSystemLeavesByParentUIDQuery_ResponsibleVariableName(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDQuery_Sorting(t *testing.T) {
 	sorting := []helpers.Sorting{{ID: "importance", DESC: true}}
-	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, &sorting, nil)
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, &sorting, nil, false)
 
 	assert.Contains(t, query.Query, "ORDER BY toLower(systems.importance.name) DESC")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_DirectOnlyNarrowsTraversal(t *testing.T) {
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil, true)
+
+	assert.Contains(t, query.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..1]->(sys:System{deleted:false})")
+	assert.NotContains(t, query.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..50]")
+	// The end-system predicate stays put — depth 1 alone would also return branches.
+	assert.Contains(t, query.Query, "WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})")
+	// Unrelated *1..50 traversals must survive: parentPath walks up to the root and
+	// statistics.subsystemsCount counts every descendant.
+	assert.Contains(t, query.Query, "OPTIONAL MATCH fullPath = (root{deleted: false})-[:HAS_SUBSYSTEM*1..50]->(sys)")
+	assert.Contains(t, query.Query, "OPTIONAL MATCH (sys)-[:HAS_SUBSYSTEM*1..50]->(subsys{deleted: false})")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_DirectOnlyOffKeepsFullTraversal(t *testing.T) {
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil, false)
+
+	assert.Contains(t, query.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..50]->(sys:System{deleted:false})")
+}
+
+func TestGetSystemLeavesByParentUIDQuery_DirectOnlyComposesWithSearchAndFilters(t *testing.T) {
+	filters := []helpers.ColumnFilter{{Id: "name", Value: "Pump"}}
+	query := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "sensor", nil, nil, &filters, true)
+
+	// Narrowing the scope must not disable search or filtering.
+	assert.Contains(t, query.Query, "HAS_SUBSYSTEM*1..1")
+	assert.Contains(t, query.Query, "toLower(sys.name) CONTAINS $filterName")
+	assert.Equal(t, "sensor", query.Parameters["search"])
 }
 
 // Count query tests
 
 func TestGetSystemLeavesByParentUIDCountQuery_NoFilters(t *testing.T) {
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", nil)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", nil, false)
 
 	assert.Equal(t, "count", query.ReturnAlias)
 	assert.Contains(t, query.Query, "RETURN COUNT(DISTINCT sys) as count")
@@ -103,7 +132,7 @@ func TestGetSystemLeavesByParentUIDCountQuery_NoFilters(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDCountQuery_ItemUsageFilter(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "itemUsage", Value: []interface{}{"usage-1"}}}
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
 	assert.Contains(t, query.Query, "MATCH (physicalItem)-[:HAS_ITEM_USAGE]->(itemUsage) WHERE itemUsage.uid IN $filterItemUsage")
@@ -112,7 +141,7 @@ func TestGetSystemLeavesByParentUIDCountQuery_ItemUsageFilter(t *testing.T) {
 func TestGetSystemLeavesByParentUIDCountQuery_PriceFilterAlone(t *testing.T) {
 	min := 100.0
 	filters := []helpers.ColumnFilter{{Id: "price", Value: map[string]interface{}{"min": min}}}
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters, false)
 
 	assert.Contains(t, query.Query, "MATCH (sys)-[:CONTAINS_ITEM]->(physicalItem)")
 	assert.Contains(t, query.Query, "ol.price >= $filterPriceFrom")
@@ -120,7 +149,7 @@ func TestGetSystemLeavesByParentUIDCountQuery_PriceFilterAlone(t *testing.T) {
 
 func TestGetSystemLeavesByParentUIDCountQuery_DynamicPropVariableScoping(t *testing.T) {
 	filters := []helpers.ColumnFilter{{Id: "prop-uid-1", Value: "test", Type: "text", PropType: "PHYSICAL_ITEM"}}
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters, false)
 
 	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem MATCH(prop{uid:")
 	assert.NotContains(t, query.Query, "WITH sys MATCH(prop{uid:")
@@ -132,11 +161,22 @@ func TestGetSystemLeavesByParentUIDCountQuery_CombinedPriceAndCatalogueName(t *t
 		{Id: "price", Value: map[string]interface{}{"min": min}},
 		{Id: "catalogueName", Value: "sensor"},
 	}
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters, false)
 
 	// Both physicalItem and catalogueItem must stay in scope
 	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem MATCH (physicalItem)<-[ol:HAS_ORDER_LINE]-(order)")
 	assert.Contains(t, query.Query, "WITH sys, physicalItem, catalogueItem WHERE toLower(catalogueItem.name) CONTAINS $filterCatalogueName")
+}
+
+func TestGetSystemLeavesByParentUIDCountQuery_DirectOnlyMatchesListTraversal(t *testing.T) {
+	// The list query derives its page count from this one, so the two traversals must
+	// agree — otherwise pagination is computed over a different set than the rows.
+	count := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", nil, true)
+	list := GetSystemLeavesByParentUIDQuery("parent-uid", "FAC", "", nil, nil, nil, true)
+
+	assert.Contains(t, count.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..1]")
+	assert.Contains(t, list.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..1]")
+	assert.NotContains(t, count.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..50]")
 }
 
 func TestGetSystemLeavesByParentUIDCountQuery_SystemLevelFilterBeforeCategory(t *testing.T) {
@@ -144,7 +184,7 @@ func TestGetSystemLeavesByParentUIDCountQuery_SystemLevelFilterBeforeCategory(t 
 		{Id: "systemLevel", Value: []interface{}{"KEY_SYSTEMS"}},
 		{Id: "category", Value: map[string]interface{}{"uid": "cat-1", "name": "Cat"}},
 	}
-	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters)
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", &filters, false)
 
 	// System-level filter should not drop category vars
 	assert.Contains(t, query.Query, "sys.systemLevel IN $filterSystemLevel")

--- a/services/systems-service/systems-db-queries_leaves_test.go
+++ b/services/systems-service/systems-db-queries_leaves_test.go
@@ -179,6 +179,12 @@ func TestGetSystemLeavesByParentUIDCountQuery_DirectOnlyMatchesListTraversal(t *
 	assert.NotContains(t, count.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..50]")
 }
 
+func TestGetSystemLeavesByParentUIDCountQuery_DirectOnlyOffKeepsFullTraversal(t *testing.T) {
+	query := GetSystemLeavesByParentUIDCountQuery("parent-uid", "FAC", "", nil, false)
+
+	assert.Contains(t, query.Query, "MATCH(parent)-[:HAS_SUBSYSTEM*1..50]->(sys:System{deleted:false})")
+}
+
 func TestGetSystemLeavesByParentUIDCountQuery_SystemLevelFilterBeforeCategory(t *testing.T) {
 	filters := []helpers.ColumnFilter{
 		{Id: "systemLevel", Value: []interface{}{"KEY_SYSTEMS"}},

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -481,8 +481,9 @@ func parseDirectOnlyParam(c echo.Context) (bool, error) {
 // @Param sorting query string false "Sorting JSON (array of {id, desc})"
 // @Param search query string false "Search text"
 // @Param columnFilter query string false "Column filter JSON"
-// @Param directOnly query bool false "Only the parent's direct children instead of all descendants"
+// @Param directOnly query bool false "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)"
 // @Success 200 {object} helpers.PaginationResult[models.System]
+// @Failure 400 "Bad request"
 // @Failure 500 "Internal server error"
 // @Router /v1/system/{uid}/leaves [get]
 func (h *SystemsHandlers) GetSystemLeavesByParentUID() echo.HandlerFunc {
@@ -541,8 +542,9 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUID() echo.HandlerFunc {
 // @Param uid path string true "Parent system UID"
 // @Param search query string false "Search text"
 // @Param columnFilter query string false "Column filter JSON"
-// @Param directOnly query bool false "Only the parent's direct children instead of all descendants"
+// @Param directOnly query bool false "Only leaf systems directly under the parent (excludes descendants deeper than 1 level)"
 // @Success 200 {object} map[string]int64
+// @Failure 400 "Bad request"
 // @Failure 500 "Internal server error"
 // @Router /v1/system/{uid}/leaves/count [get]
 func (h *SystemsHandlers) GetSystemLeavesByParentUIDCount() echo.HandlerFunc {

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -458,6 +458,18 @@ func (h *SystemsHandlers) GetSystemsHierarchy() echo.HandlerFunc {
 	}
 }
 
+// parseDirectOnlyParam reads the optional directOnly flag shared by both leaves
+// endpoints. Absent means false; anything ParseBool rejects is an error rather than a
+// silent false, so a client sending `directOnly=1` finds out instead of quietly getting
+// the whole subtree back. Mirrors the includeRelationshipStats handling below.
+func parseDirectOnlyParam(c echo.Context) (bool, error) {
+	raw := strings.TrimSpace(c.QueryParam("directOnly"))
+	if raw == "" {
+		return false, nil
+	}
+	return strconv.ParseBool(raw)
+}
+
 // GetSystemLeavesByParentUID godoc
 // @Summary Get leaf systems for a parent
 // @Description Returns a paginated list of leaf systems (systems without subsystems) recursively under the given parent system.
@@ -505,7 +517,10 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUID() echo.HandlerFunc {
 		filter := c.QueryParam("columnFilter")
 		json.Unmarshal([]byte(filter), &filterObject)
 
-		directOnly := c.QueryParam("directOnly") == "true"
+		directOnly, err := parseDirectOnlyParam(c)
+		if err != nil {
+			return helpers.BadRequest("invalid directOnly")
+		}
 
 		items, err := h.systemsService.GetSystemLeavesByParentUID(parentUID, facilityCode, search, pagingObject, sortingObject, filterObject, directOnly)
 		if err == nil {
@@ -540,7 +555,10 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUIDCount() echo.HandlerFunc {
 		filter := c.QueryParam("columnFilter")
 		json.Unmarshal([]byte(filter), &filterObject)
 
-		directOnly := c.QueryParam("directOnly") == "true"
+		directOnly, err := parseDirectOnlyParam(c)
+		if err != nil {
+			return helpers.BadRequest("invalid directOnly")
+		}
 
 		count, err := h.systemsService.GetSystemLeavesByParentUIDCount(parentUID, facilityCode, search, filterObject, directOnly)
 		if err == nil {

--- a/services/systems-service/systems-handlers.go
+++ b/services/systems-service/systems-handlers.go
@@ -469,6 +469,7 @@ func (h *SystemsHandlers) GetSystemsHierarchy() echo.HandlerFunc {
 // @Param sorting query string false "Sorting JSON (array of {id, desc})"
 // @Param search query string false "Search text"
 // @Param columnFilter query string false "Column filter JSON"
+// @Param directOnly query bool false "Only the parent's direct children instead of all descendants"
 // @Success 200 {object} helpers.PaginationResult[models.System]
 // @Failure 500 "Internal server error"
 // @Router /v1/system/{uid}/leaves [get]
@@ -504,7 +505,9 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUID() echo.HandlerFunc {
 		filter := c.QueryParam("columnFilter")
 		json.Unmarshal([]byte(filter), &filterObject)
 
-		items, err := h.systemsService.GetSystemLeavesByParentUID(parentUID, facilityCode, search, pagingObject, sortingObject, filterObject)
+		directOnly := c.QueryParam("directOnly") == "true"
+
+		items, err := h.systemsService.GetSystemLeavesByParentUID(parentUID, facilityCode, search, pagingObject, sortingObject, filterObject, directOnly)
 		if err == nil {
 			return c.JSON(http.StatusOK, items)
 		}
@@ -523,6 +526,7 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUID() echo.HandlerFunc {
 // @Param uid path string true "Parent system UID"
 // @Param search query string false "Search text"
 // @Param columnFilter query string false "Column filter JSON"
+// @Param directOnly query bool false "Only the parent's direct children instead of all descendants"
 // @Success 200 {object} map[string]int64
 // @Failure 500 "Internal server error"
 // @Router /v1/system/{uid}/leaves/count [get]
@@ -536,7 +540,9 @@ func (h *SystemsHandlers) GetSystemLeavesByParentUIDCount() echo.HandlerFunc {
 		filter := c.QueryParam("columnFilter")
 		json.Unmarshal([]byte(filter), &filterObject)
 
-		count, err := h.systemsService.GetSystemLeavesByParentUIDCount(parentUID, facilityCode, search, filterObject)
+		directOnly := c.QueryParam("directOnly") == "true"
+
+		count, err := h.systemsService.GetSystemLeavesByParentUIDCount(parentUID, facilityCode, search, filterObject, directOnly)
 		if err == nil {
 			return c.JSON(http.StatusOK, map[string]int64{"count": count})
 		}

--- a/services/systems-service/systems-leaves-params_test.go
+++ b/services/systems-service/systems-leaves-params_test.go
@@ -1,0 +1,61 @@
+package systemsService
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+func directOnlyContext(rawQuery string) echo.Context {
+	e := echo.New()
+	target := "/v1/system/parent-uid/leaves"
+	if rawQuery != "" {
+		target += "?" + rawQuery
+	}
+	return e.NewContext(httptest.NewRequest(http.MethodGet, target, nil), httptest.NewRecorder())
+}
+
+func TestParseDirectOnlyParam_AbsentDefaultsToFalse(t *testing.T) {
+	// Absent must stay the full-subtree behaviour — this is the pre-existing contract.
+	got, err := parseDirectOnlyParam(directOnlyContext(""))
+
+	assert.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestParseDirectOnlyParam_EmptyValueDefaultsToFalse(t *testing.T) {
+	// `?directOnly=` is what a client sends when it serialises an unset flag; it must
+	// not be an error.
+	got, err := parseDirectOnlyParam(directOnlyContext("directOnly="))
+
+	assert.NoError(t, err)
+	assert.False(t, got)
+}
+
+func TestParseDirectOnlyParam_AcceptsBoolEncodings(t *testing.T) {
+	truthy := []string{"true", "TRUE", "True", "1", "t"}
+	for _, raw := range truthy {
+		got, err := parseDirectOnlyParam(directOnlyContext("directOnly=" + raw))
+		assert.NoError(t, err, raw)
+		assert.True(t, got, raw)
+	}
+
+	falsy := []string{"false", "FALSE", "0", "f"}
+	for _, raw := range falsy {
+		got, err := parseDirectOnlyParam(directOnlyContext("directOnly=" + raw))
+		assert.NoError(t, err, raw)
+		assert.False(t, got, raw)
+	}
+}
+
+func TestParseDirectOnlyParam_RejectsGarbage(t *testing.T) {
+	// Silently falling back to false would hand the caller the whole subtree while
+	// they believe they asked for direct children only.
+	for _, raw := range []string{"yes", "on", "2", "null"} {
+		_, err := parseDirectOnlyParam(directOnlyContext("directOnly=" + raw))
+		assert.Error(t, err, raw)
+	}
+}

--- a/services/systems-service/systems-service.go
+++ b/services/systems-service/systems-service.go
@@ -39,8 +39,8 @@ type ISystemsService interface {
 	GetSystemsAutocompleteCodebook(searchText string, limit int, facilityCode string, filter *[]helpers.Filter) (result []codebookModels.Codebook, err error)
 	GetSystemsWithSearchAndPagination(search string, facilityCode string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filering *[]helpers.ColumnFilter) (result helpers.PaginationResult[models.System], err error)
 	GetSystemsHierarchy(facilityCode string) (result []models.SystemHierarchyNode, err error)
-	GetSystemLeavesByParentUID(parentUID string, facilityCode string, search string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter) (result helpers.PaginationResult[models.System], err error)
-	GetSystemLeavesByParentUIDCount(parentUID string, facilityCode string, search string, filtering *[]helpers.ColumnFilter) (count int64, err error)
+	GetSystemLeavesByParentUID(parentUID string, facilityCode string, search string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter, directOnly bool) (result helpers.PaginationResult[models.System], err error)
+	GetSystemLeavesByParentUIDCount(parentUID string, facilityCode string, search string, filtering *[]helpers.ColumnFilter, directOnly bool) (count int64, err error)
 	GetSystemGraphByUid(uid string, facilityCode string, options models.SystemGraphQueryOptions) (result models.SystemGraphResponse, err error)
 	GetSystemsForRelationship(search string, facilityCode string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filering *[]helpers.ColumnFilter, systemFromUid string, relationTypeCode string) (result helpers.PaginationResult[models.System], err error)
 	GetSystemRelationships(uid string) (result []models.SystemRelationship, err error)
@@ -566,21 +566,23 @@ func (svc *SystemsService) GetSystemsHierarchy(facilityCode string) (result []mo
 	return result, nil
 }
 
-func (svc *SystemsService) GetSystemLeavesByParentUID(parentUID string, facilityCode string, search string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter) (result helpers.PaginationResult[models.System], err error) {
+func (svc *SystemsService) GetSystemLeavesByParentUID(parentUID string, facilityCode string, search string, pagination *helpers.Pagination, sorting *[]helpers.Sorting, filtering *[]helpers.ColumnFilter, directOnly bool) (result helpers.PaginationResult[models.System], err error) {
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 
-	query := GetSystemLeavesByParentUIDQuery(parentUID, facilityCode, search, pagination, sorting, filtering)
+	query := GetSystemLeavesByParentUIDQuery(parentUID, facilityCode, search, pagination, sorting, filtering, directOnly)
 	items, err := helpers.GetNeo4jArrayOfNodes[models.System](session, query)
-	totalCount, _ := helpers.GetNeo4jSingleRecordSingleValue[int64](session, GetSystemLeavesByParentUIDCountQuery(parentUID, facilityCode, search, filtering))
+	// directOnly must match the list query, otherwise the page count is computed over
+	// the full descendant set while the rows come from the direct children only.
+	totalCount, _ := helpers.GetNeo4jSingleRecordSingleValue[int64](session, GetSystemLeavesByParentUIDCountQuery(parentUID, facilityCode, search, filtering, directOnly))
 
 	result = helpers.GetPaginationResult(items, int64(totalCount), err)
 	return result, err
 }
 
-func (svc *SystemsService) GetSystemLeavesByParentUIDCount(parentUID string, facilityCode string, search string, filtering *[]helpers.ColumnFilter) (count int64, err error) {
+func (svc *SystemsService) GetSystemLeavesByParentUIDCount(parentUID string, facilityCode string, search string, filtering *[]helpers.ColumnFilter, directOnly bool) (count int64, err error) {
 	session, _ := helpers.NewNeo4jSession(*svc.neo4jDriver)
 
-	count, err = helpers.GetNeo4jSingleRecordSingleValue[int64](session, GetSystemLeavesByParentUIDCountQuery(parentUID, facilityCode, search, filtering))
+	count, err = helpers.GetNeo4jSingleRecordSingleValue[int64](session, GetSystemLeavesByParentUIDCountQuery(parentUID, facilityCode, search, filtering, directOnly))
 
 	return count, err
 }


### PR DESCRIPTION
## Proč

Strom v hierarchii vrací jen uzly, které mají potomky — koncové systémy v něm nejsou nikdy vidět. Tabulka vedle stromu (`/system/{uid}/leaves`) naopak vrací všechny koncové systémy do hloubky 1..50. Uzel s pár přímými listy a podstromem o tisících listů tak ty přímé utopí a uživatel nemá jak se k nim dostat.

Chybí optika „co visí přímo pod tímhle uzlem".

## Co se mění

Volitelný `?directOnly=true` na `/v1/system/{uid}/leaves` a `/leaves/count`.

Klíčové je, že query už koncovost řeší přes `WHERE NOT (sys)-[:HAS_SUBSYSTEM]->(:System{deleted:false})`. Jediné, co dělí „všechny listy pod uzlem" od „přímé koncové děti", je hloubka traversalu. Param ji přepne z `*1..50` na `*1..1` — žádný další predikát není potřeba a `depth 1` tím pádem znamená přesně „koncové systémy visící přímo pod rodičem".

- `leavesTraversalDepth(bool)` — jediné místo, kde se hloubka volí, sdílené list i count query
- `directOnly` protažen handler → service → obě query funkce
- **Interní count volání v `GetSystemLeavesByParentUID` dostává stejnou hodnotu** — jinak by se stránkování počítalo nad plnou množinou potomků, zatímco řádky by přišly jen z přímých dětí
- Swagger anotace + `make swagger` (diff v `docs/` a `open-api-specification/` obsahuje jen nový parametr)

Default `false` = dnešní chování. Žádná změna existujícího kontraktu.

## Proč bool a ne `depth=N`

`depth=3` by míchalo listy z hloubek 1–3 dohromady, což není srozumitelná množina. Bool vyjadřuje záměr a nemá nevalidní hodnoty k ošetření.

## Testy

`services/systems-service/systems-db-queries_leaves_test.go`:

- `directOnly=true` → parent traversal je `*1..1`, `false` → `*1..50`
- predikát koncovosti zůstává (bez něj by depth 1 vrátila i větve)
- **nesouvisející `*1..50` přežívají** — `parentPath` chodí nahoru ke kořeni a `statistics.subsystemsCount` počítá všechny potomky; první verze asercí tohle nerozlišila a test to odhalil
- list i count query se v hloubce shodují (stránkování vs. řádky)
- `directOnly` se skládá se search i filtry

`go test ./services/systems-service/...` a `go vet` zelené.

## Souvislosti

Frontend, který parametr používá: eli-eric/ELI-panda#1143 (checkbox „Direct only" v hierarchii). FE se nasazuje nezávisle — do doby, než je tenhle PR venku, je parametr ignorován a checkbox vrací plný seznam.